### PR TITLE
Add PF2e token bar module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Kazguls-PF2e-Token-Bar
+
+Displays a bar of active player tokens for PF2e games. Clicking a token opens the actor's character sheet. Includes a button for the GM to request rolls, presenting a dialog to choose tokens, skills or saving throws, and a DC. Compatible with Foundry VTT version 13.

--- a/module.json
+++ b/module.json
@@ -1,0 +1,24 @@
+{
+  "id": "pf2e-token-bar",
+  "title": "PF2e Token Bar",
+  "description": "Displays active player tokens and allows roll requests",
+  "version": "0.1.0",
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13"
+  },
+  "systems": ["pf2e"],
+  "authors": [
+    {
+      "name": "Kazgul"
+    }
+  ],
+  "esmodules": [
+    "scripts/token-bar.js"
+  ],
+  "styles": [
+    "styles/token-bar.css"
+  ],
+  "manifest": "https://example.com/module.json",
+  "download": "https://example.com/module.zip"
+}

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -1,0 +1,76 @@
+class PF2ETokenBar {
+  static render() {
+    if (!canvas?.ready) return;
+    const tokens = this._activePlayerTokens();
+    if (!tokens.length) return;
+    let bar = document.getElementById("pf2e-token-bar");
+    if (bar) bar.remove();
+    bar = document.createElement("div");
+    bar.id = "pf2e-token-bar";
+    tokens.forEach(t => {
+      const img = document.createElement("img");
+      img.src = t.document.texture.src;
+      img.title = t.document.name;
+      img.classList.add("pf2e-token-bar-token");
+      img.addEventListener("click", () => t.actor?.sheet.render(true));
+      bar.appendChild(img);
+    });
+    const btn = document.createElement("button");
+    btn.innerText = game.i18n?.localize("PF2E.Roll") || "Request Roll";
+    btn.addEventListener("click", () => this.requestRoll());
+    bar.appendChild(btn);
+    document.body.appendChild(bar);
+  }
+
+  static _activePlayerTokens() {
+    return canvas.tokens.placeables.filter(t => t.actor?.hasPlayerOwner);
+  }
+
+  static requestRoll() {
+    const tokens = this._activePlayerTokens();
+    const tokenOptions = tokens.map(t => `<div><input type="checkbox" name="token" value="${t.id}"/> ${t.document.name}</div>`).join("");
+    const skills = CONFIG.PF2E?.skills || {};
+    const skillOptions = Object.entries(skills).map(([k,v]) => `<option value="${k}">${v.label ?? v}</option>`).join("");
+    const saveOptions = ["fortitude","reflex","will"].map(s => `<option value="${s}">${s}</option>`).join("");
+    const content = `<div><label>DC <input type="number" name="dc"/></label></div>
+    <div class="flexrow">
+      <div class="token-select">${tokenOptions}</div>
+      <div class="skill-select">
+        <select name="skill">${skillOptions}<optgroup label="Saves">${saveOptions}</optgroup></select>
+      </div>
+    </div>`;
+    new Dialog({
+      title: "Request Roll",
+      content,
+      buttons: {
+        roll: {
+          label: "Roll",
+          callback: html => {
+            const form = html[0].querySelector("form") || html[0];
+            const dc = Number(form.querySelector('input[name="dc"]').value) || undefined;
+            const skill = form.querySelector('select[name="skill"]').value;
+            const selected = Array.from(form.querySelectorAll('input[name="token"]:checked')).map(i => i.value);
+            selected.forEach(id => {
+              const token = canvas.tokens.get(id);
+              const actor = token?.actor;
+              if (!actor) return;
+              if (["fortitude","reflex","will"].includes(skill)) {
+                actor.saves[skill]?.check.roll({dc: dc ? {value: dc} : undefined});
+              } else {
+                actor.skills[skill]?.check.roll({dc: dc ? {value: dc} : undefined});
+              }
+            });
+          }
+        },
+        cancel: { label: "Cancel" }
+      },
+      default: "roll"
+    }).render(true);
+  }
+}
+
+Hooks.on("canvasReady", () => PF2ETokenBar.render());
+Hooks.on("updateToken", () => PF2ETokenBar.render());
+Hooks.on("createToken", () => PF2ETokenBar.render());
+Hooks.on("deleteToken", () => PF2ETokenBar.render());
+

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -1,0 +1,15 @@
+#pf2e-token-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: rgba(0,0,0,0.5);
+}
+
+#pf2e-token-bar img.pf2e-token-bar-token {
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- display active player tokens in a PF2e scene and open character sheets on click
- add GM roll-request dialog for skills and saving throws with DC input
- include basic styling and module manifest
- mark compatibility with Foundry VTT 13 and update token references for v13 APIs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b27003904832784a530a5decbcede