### PR TITLE
Use actor IDs for party token lookup

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -26,8 +26,9 @@ class PF2ETokenBar {
   }
 
   static _partyTokens() {
-    const partyMembers = game.actors.party?.members || [];
-    return canvas.tokens.placeables.filter(t => t.actor && partyMembers.includes(t.actor));
+    const partyIds = (game.actors.party?.members ?? []).map(a => a.id);
+    if (!partyIds.length) return this._activePlayerTokens();
+    return canvas.tokens.placeables.filter(t => t.actor && partyIds.includes(t.actor.id));
   }
 
   static requestRoll() {


### PR DESCRIPTION
## Summary
- Compare actor IDs when selecting party tokens
- Fallback to active player tokens when no party is defined

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689c2e1e73808327a44d8ec1f1fb45ca