### PR TITLE
fix: remove duplicate token assignments

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -12,8 +12,6 @@ class PF2ETokenBar {
       const img = document.createElement("img");
       img.src = t.document.texture.src;
       img.title = t.document.name;
-      img.src = t.texture.src;
-      img.title = t.name;
       img.classList.add("pf2e-token-bar-token");
       img.addEventListener("click", () => t.actor?.sheet.render(true));
       bar.appendChild(img);


### PR DESCRIPTION
## Summary
- remove duplicated token image and title assignments

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e1470888327b3a42b814ab3269e