### PR TITLE
Remove duplicated description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
 # Kazguls-PF2e-Token-Bar
 
-
 Displays a bar of party member tokens present in the scene at the top-right of the screen for PF2e games. Clicking a token opens the actor's character sheet. Includes a button for the GM to request rolls, presenting a dialog to choose tokens, skills or saving throws, and a DC. Compatible with Foundry VTT version 13.
-
-Displays a bar of active player tokens for PF2e games. Clicking a token opens the actor's character sheet. Includes a button for the GM to request rolls, presenting a dialog to choose tokens, skills or saving throws, and a DC. Compatible with Foundry VTT version 13.
-Displays a bar of active player tokens for PF2e games. Clicking a token opens the actor's character sheet. Includes a button for the GM to request rolls, presenting a dialog to choose tokens, skills or saving throws, and a DC. Compatible with Foundry VTT version 13.
-Displays a bar of active player tokens for PF2e games. Clicking a token opens the actor's character sheet. Includes a button for the GM to request rolls, presenting a dialog to choose tokens, skills or saving throws, and a DC.
 


### PR DESCRIPTION
## Summary
- deduplicated README description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e287c248327a72ca4b27e2824ea