### PR TITLE
feat: make token bar draggable

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -1,11 +1,11 @@
 #pf2e-token-bar {
   position: absolute;
   top: 0;
-  right: 0;
   display: flex;
   gap: 4px;
   padding: 4px;
   background: rgba(0,0,0,0.5);
+  cursor: move;
 }
 
 #pf2e-token-bar img.pf2e-token-bar-token {


### PR DESCRIPTION
## Summary
- allow token bar to be dragged and persist its coordinates
- register per-client setting to remember bar position
- add move cursor style for bar

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c3687c7e0832781a1bbdcfa2aee1d