### PR TITLE
Use skill labels in token bar roll links

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -115,7 +115,8 @@ class PF2ETokenBar {
             selected.forEach(id => {
               const token = canvas.tokens.get(id);
               if (!token?.actor) return;
-              const link = `<a class="pf2e-token-bar-roll" data-token-id="${id}" data-skill="${skill}" data-dc="${dc ?? ""}">DC ${dc ?? ""} ${skill}</a>`;
+              const skillLabel = CONFIG.PF2E?.skills[skill]?.label ?? skill;
+              const link = `<a class="pf2e-token-bar-roll" data-token-id="${id}" data-skill="${skill}" data-dc="${dc ?? ""}">${skillLabel}</a>`;
               const content = `${token.name ? token.name + ": " : ""}${link}`;
               ChatMessage.create({ content });
             });


### PR DESCRIPTION
## Summary
- derive skill label from `CONFIG.PF2E.skills` and use it for roll link text
- hide DC from chat link while retaining `data-dc` value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c529e7c8327a74cefe02c3c46ee