### PR TITLE
Show token image in roll request chat message

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -117,7 +117,8 @@ class PF2ETokenBar {
               if (!token?.actor) return;
               const skillLabel = CONFIG.PF2E?.skills[skill]?.label ?? skill;
               const link = `<a class="pf2e-token-bar-roll" data-token-id="${id}" data-skill="${skill}" data-dc="${dc ?? ""}">${skillLabel}</a>`;
-              const content = `${token.name ? token.name + ": " : ""}${link}`;
+              const img = `<img class="pf2e-token-bar-chat-token" src="${token.document.texture.src}"/>`;
+              const content = `${token.name ? token.name + ": " : ""}${img}${link}`;
               ChatMessage.create({ content });
             });
           }

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -20,3 +20,10 @@
   border-radius: 3px;
   background: var(--color-bg-alt);
 }
+
+.chat-message img.pf2e-token-bar-chat-token {
+  width: 1em;
+  height: 1em;
+  margin-right: 4px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
## Summary
- Display token image before the skill link when requesting rolls
- Style token image in chat messages

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c4019eab4832783bc0935419507e1