### PR TITLE
Localize skill labels for token bar rolls

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -91,7 +91,13 @@ class PF2ETokenBar {
     const tokens = this._activePlayerTokens();
     const tokenOptions = tokens.map(t => `<div><input type="checkbox" name="token" value="${t.id}"/> ${t.name}</div>`).join("");
     const skills = CONFIG.PF2E?.skills || {};
-    const skillOptions = Object.entries(skills).map(([k,v]) => `<option value="${k}">${v.label ?? v}</option>`).join("");
+    const skillOptions = Object.entries(skills)
+      .map(([k, v]) => {
+        const label = v.label ?? v;
+        const localized = game.i18n?.localize(label) ?? label;
+        return `<option value="${k}">${localized}</option>`;
+      })
+      .join("");
     const saveOptions = ["fortitude","reflex","will"].map(s => `<option value="${s}">${s}</option>`).join("");
     const content = `<div><label>DC <input type="number" name="dc"/></label></div>
     <div class="flexrow">
@@ -115,7 +121,8 @@ class PF2ETokenBar {
             selected.forEach(id => {
               const token = canvas.tokens.get(id);
               if (!token?.actor) return;
-              const skillLabel = CONFIG.PF2E?.skills[skill]?.label ?? skill;
+              const skillLabelKey = CONFIG.PF2E?.skills[skill]?.label ?? skill;
+              const skillLabel = game.i18n?.localize(skillLabelKey) ?? skillLabelKey;
               const link = `<a class="pf2e-token-bar-roll" data-token-id="${id}" data-skill="${skill}" data-dc="${dc ?? ""}">${skillLabel}</a>`;
               const content = `${token.name ? token.name + ": " : ""}${link}`;
               ChatMessage.create({ content });


### PR DESCRIPTION
## Summary
- localize skill names in dropdown options
- localize skill labels in chat links

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c4018d65483278da627cf764a12a8