### PR TITLE
feat: enlarge tokens to 64px

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -2,15 +2,15 @@
   position: absolute;
   top: 0;
   display: flex;
-  gap: 4px;
-  padding: 4px;
+  gap: 8px;
+  padding: 8px;
   background: rgba(0,0,0,0.5);
   cursor: move;
 }
 
 #pf2e-token-bar img.pf2e-token-bar-token {
-  width: 32px;
-  height: 32px;
+  width: 64px;
+  height: 64px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- Increase token icons to 64px square
- Double container padding and gap to 8px for spacing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4b4bcd0c832785e707de98ef345a