### PR TITLE
Display HP bars for tokens in party bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -28,12 +28,35 @@ class PF2ETokenBar {
       bar.style.right = "0px";
     }
     tokens.forEach(t => {
+      const wrapper = document.createElement("div");
+      wrapper.classList.add("pf2e-token-wrapper");
+
       const img = document.createElement("img");
       img.src = t.document.texture.src;
       img.title = t.document.name;
       img.classList.add("pf2e-token-bar-token");
       img.addEventListener("click", () => t.actor?.sheet.render(true));
-      bar.appendChild(img);
+      wrapper.appendChild(img);
+
+      const hp = t.actor?.system?.attributes?.hp ?? {};
+      const hpValue = Number(hp.value) || 0;
+      const hpMax = Number(hp.max) || 0;
+
+      const hpText = document.createElement("div");
+      hpText.classList.add("pf2e-hp-text");
+      hpText.innerText = `${hpValue}`;
+      wrapper.appendChild(hpText);
+
+      const barOuter = document.createElement("div");
+      barOuter.classList.add("pf2e-hp-bar");
+      const barInner = document.createElement("div");
+      barInner.classList.add("pf2e-hp-bar-inner");
+      const pct = hpMax > 0 ? Math.min(Math.max((hpValue / hpMax) * 100, 0), 100) : 0;
+      barInner.style.width = `${pct}%`;
+      barOuter.appendChild(barInner);
+      wrapper.appendChild(barOuter);
+
+      bar.appendChild(wrapper);
     });
     const btn = document.createElement("button");
     btn.innerText = game.i18n?.localize("PF2E.Roll") || "Request Roll";
@@ -156,6 +179,9 @@ Hooks.on("canvasReady", () => PF2ETokenBar.render());
 Hooks.on("updateToken", () => PF2ETokenBar.render());
 Hooks.on("createToken", () => PF2ETokenBar.render());
 Hooks.on("deleteToken", () => PF2ETokenBar.render());
+Hooks.on("updateActor", (_actor, data) => {
+  if (data.system?.attributes?.hp) PF2ETokenBar.render();
+});
 Hooks.on("renderChatMessage", (_message, html) => {
   const links = html[0]?.querySelectorAll("a.pf2e-token-bar-roll") ?? [];
   for (const link of links) {

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -14,6 +14,28 @@
   cursor: pointer;
 }
 
+#pf2e-token-bar .pf2e-token-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#pf2e-token-bar .pf2e-hp-text {
+  font-size: 12px;
+  line-height: 1;
+}
+
+#pf2e-token-bar .pf2e-hp-bar {
+  width: 100%;
+  height: 4px;
+  background: rgba(255,255,255,0.2);
+}
+
+#pf2e-token-bar .pf2e-hp-bar-inner {
+  height: 100%;
+  background: red;
+}
+
 .chat-message a.pf2e-token-bar-roll {
   padding: 2px 4px;
   border: 1px solid var(--color-border-light-primary);


### PR DESCRIPTION
## Summary
- Wrap each token image with a container showing current HP and a small HP bar
- Style token wrapper, HP text, and HP bar for column layout and 4px bar height
- Re-render token bar on actor HP updates to keep values current

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4c92027c8327a32bef38f19cdf76