### PR TITLE
cleanup party token filter logging

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -74,11 +74,11 @@ class PF2ETokenBar {
   static _partyTokens() {
     const partyMembers = game.actors.party?.members || [];
     const tokens = canvas.tokens.placeables.filter(t => t.actor && partyMembers.includes(t.actor));
-    console.log(`PF2ETokenBar | _partyTokens filtered ${tokens.length} tokens`, tokens.map(t => t.actor.id));
+    console.log(
+      `PF2ETokenBar | _partyTokens filtered ${tokens.length} tokens`,
+      tokens.map(t => t.id)
+    );
     return tokens;
-    const partyIds = (game.actors.party?.members ?? []).map(a => a.id);
-    if (!partyIds.length) return this._activePlayerTokens();
-    return canvas.tokens.placeables.filter(t => t.actor && partyIds.includes(t.actor.id));
   }
 
   static _activePlayerTokens() {


### PR DESCRIPTION
## Summary
- remove unreachable code from party token filter
- log token IDs when collecting party tokens

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4f1d1b348327947ab8cdf0c4fe51