### PR TITLE
Fix healAll method outside restAll

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -125,6 +125,8 @@ class PF2ETokenBar {
     if (!actors.length) return;
     await game.pf2e.actions.restForTheNight({ actors });
     this.render();
+  }
+
   static async healAll() {
     const confirmed = await Dialog.confirm({
       title: "Heal All",


### PR DESCRIPTION
## Summary
- fix restAll block to properly close before healAll
- ensure healAll is defined outside restAll

## Testing
- `node --check scripts/token-bar.js`


------
https://chatgpt.com/codex/tasks/task_e_689f5365a5248327b7adb7ce8ab0b14e