### PR TITLE
Add effect icons to token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -60,6 +60,20 @@ class PF2ETokenBar {
       barOuter.appendChild(barInner);
       wrapper.appendChild(barOuter);
 
+      const effectBar = document.createElement("div");
+      effectBar.classList.add("pf2e-effect-bar");
+      const effects = t.actor?.itemTypes?.effect || [];
+      for (const effect of effects.filter(e => !e.disabled && !e.isExpired)) {
+        const icon = document.createElement("img");
+        icon.classList.add("pf2e-effect-icon");
+        icon.src = effect.img;
+        icon.title = effect.name;
+        const desc = effect.system?.description?.value || effect.system?.description || "";
+        icon.addEventListener("mouseenter", event => ui.tooltip?.activate(event.currentTarget, { html: desc }));
+        effectBar.appendChild(icon);
+      }
+      wrapper.appendChild(effectBar);
+
       content.appendChild(wrapper);
     });
     const healBtn = document.createElement("button");

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -49,6 +49,20 @@
   background: red;
 }
 
+.pf2e-effect-bar {
+  display: flex;
+  gap: 2px;
+}
+
+.pf2e-effect-icon {
+  width: 16px;
+  height: 16px;
+}
+
+#pf2e-token-bar.collapsed .pf2e-effect-bar {
+  display: none;
+}
+
 .chat-message a.pf2e-token-bar-roll {
   padding: 2px 4px;
   border: 1px solid var(--color-border-light-primary);


### PR DESCRIPTION
## Summary
- show active effect icons next to each token
- style effect icons and hide them when the bar is collapsed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689faa7d90248327b3b64a771a6d2731