### PR TITLE
Add handle-based dragging to token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -27,6 +27,10 @@ class PF2ETokenBar {
       bar.style.top = "0px";
       bar.style.right = "0px";
     }
+    const handle = document.createElement("div");
+    handle.classList.add("pf2e-bar-handle");
+    handle.innerHTML = '<i class="fas fa-anchor"></i>';
+    bar.appendChild(handle);
     const content = document.createElement("div");
     content.classList.add("pf2e-token-bar-content");
     bar.appendChild(content);
@@ -117,8 +121,8 @@ class PF2ETokenBar {
       game.settings.set("pf2e-token-bar", "position", { top: bar.offsetTop, left: bar.offsetLeft });
     };
 
-    bar.addEventListener("mousedown", event => {
-      if (event.target !== bar && event.target !== content) return;
+    handle.addEventListener("mousedown", event => {
+      event.preventDefault();
       dragging = true;
       offsetX = event.clientX - bar.offsetLeft;
       offsetY = event.clientY - bar.offsetTop;

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -5,7 +5,6 @@
   gap: 8px;
   padding: 8px;
   background: rgba(0,0,0,0.5);
-  cursor: move;
 }
 
 #pf2e-token-bar .pf2e-token-bar-content {
@@ -57,6 +56,16 @@
 .pf2e-effect-icon {
   width: 16px;
   height: 16px;
+}
+
+#pf2e-token-bar .pf2e-bar-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  cursor: move;
+  margin-right: 4px;
 }
 
 #pf2e-token-bar.collapsed .pf2e-effect-bar {


### PR DESCRIPTION
## Summary
- Add anchor handle to token bar and use it for dragging
- Style new handle element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb30bfdd08327a567ed7e0dd95db5