### PR TITLE
Allow removing token bar effects via right-click

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -70,6 +70,11 @@ class PF2ETokenBar {
         icon.title = effect.name;
         const desc = effect.system?.description?.value || effect.system?.description || "";
         icon.addEventListener("mouseenter", event => ui.tooltip?.activate(event.currentTarget, { html: desc }));
+        icon.addEventListener("contextmenu", async event => {
+          event.preventDefault();
+          event.stopPropagation();
+          await t.actor.deleteEmbeddedDocuments("Item", [effect.id]);
+        });
         effectBar.appendChild(icon);
       }
       wrapper.appendChild(effectBar);


### PR DESCRIPTION
## Summary
- remove effects from token bar with right-click context menu

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb30e61a483279ec4720fdf62d9c5