### PR TITLE
Enrich effect tooltips in token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -69,7 +69,11 @@ class PF2ETokenBar {
         icon.src = effect.img;
         icon.title = effect.name;
         const desc = effect.system?.description?.value || effect.system?.description || "";
-        icon.addEventListener("mouseenter", event => ui.tooltip?.activate(event.currentTarget, { html: desc }));
+        icon.addEventListener("mouseenter", async event => {
+          const html = await TextEditor.enrichHTML(desc, { async: true });
+          ui.tooltip?.activate(event.currentTarget, { html });
+        });
+        icon.addEventListener("mouseleave", () => ui.tooltip?.deactivate());
         effectBar.appendChild(icon);
       }
       wrapper.appendChild(effectBar);


### PR DESCRIPTION
## Summary
- Use `TextEditor.enrichHTML` to render effect descriptions in tooltips
- Hide effect tooltips on mouse leave

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb30f46448327951b20870b1f18f9