### PR TITLE
Restrict token bar to GMs with toggle

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -5,11 +5,25 @@ Hooks.once("init", () => {
     type: Object,
     default: {}
   });
+  game.settings.register("pf2e-token-bar", "enabled", {
+    name: "PF2E Token Bar",
+    hint: "Show the PF2E Token Bar",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: () => PF2ETokenBar.render()
+  });
 });
 
 class PF2ETokenBar {
   static render() {
     if (!canvas?.ready) return;
+    if (!game.user.isGM) return;
+    if (!game.settings.get("pf2e-token-bar", "enabled")) {
+      document.getElementById("pf2e-token-bar")?.remove();
+      return;
+    }
 
     console.log("PF2ETokenBar | fetching party tokens");
     const tokens = this._partyTokens();


### PR DESCRIPTION
## Summary
- render token bar only for GMs
- add client-side setting to enable or hide the bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a04804a7408327aca5ca394f73c896