### PR TITLE
Remove redundant effect tooltip listener

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -92,7 +92,6 @@ class PF2ETokenBar {
           ui.tooltip?.activate(event.currentTarget, { html });
         });
         icon.addEventListener("mouseleave", () => ui.tooltip?.deactivate());
-        icon.addEventListener("mouseenter", event => ui.tooltip?.activate(event.currentTarget, { html: desc }));
         icon.addEventListener("contextmenu", async event => {
           event.preventDefault();
           event.stopPropagation();


### PR DESCRIPTION
## Summary
- remove duplicate `mouseenter` handler for effect icons so the tooltip uses enriched HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0539f61d08327b9afd822be1d541b