### PR TITLE
feat: enlarge effect icons

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -50,12 +50,12 @@
 
 .pf2e-effect-bar {
   display: flex;
-  gap: 2px;
+  gap: 3px;
 }
 
 .pf2e-effect-icon {
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
 }
 
 #pf2e-token-bar .pf2e-bar-handle {


### PR DESCRIPTION
## Summary
- enlarge effect icons in token bar to 24px
- adjust effect bar gap to maintain layout

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a09e71b1d483279c6608166523197a