### PR TITLE
Refresh token bar after effect changes

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -96,6 +96,7 @@ class PF2ETokenBar {
           event.preventDefault();
           event.stopPropagation();
           await t.actor.deleteEmbeddedDocuments("Item", [effect.id]);
+          PF2ETokenBar.render();
         });
         effectBar.appendChild(icon);
       }
@@ -269,6 +270,12 @@ Hooks.on("createToken", () => PF2ETokenBar.render());
 Hooks.on("deleteToken", () => PF2ETokenBar.render());
 Hooks.on("updateActor", (_actor, data) => {
   if (data.system?.attributes?.hp) PF2ETokenBar.render();
+});
+Hooks.on("deleteItem", item => {
+  if (item.isOfType?.("effect") || item.type === "effect") PF2ETokenBar.render();
+});
+Hooks.on("updateItem", item => {
+  if (item.isOfType?.("effect") || item.type === "effect") PF2ETokenBar.render();
 });
 Hooks.on("renderChatMessage", (_message, html) => {
   const links = html[0]?.querySelectorAll("a.pf2e-token-bar-roll") ?? [];


### PR DESCRIPTION
## Summary
- re-render token bar when effect icons are removed via context menu
- watch effect item updates and deletions to refresh bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a09e7db5948327b030616c319b4602