### PR TITLE
Add hover targeting and indicator to token bar

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -30,6 +30,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 }
 
 #pf2e-token-bar .pf2e-hp-text {
@@ -84,4 +85,12 @@
   height: 3em;
   margin-right: 4px;
   vertical-align: middle;
+}
+
+.target-indicator {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 12px;
+  display: none;
 }


### PR DESCRIPTION
## Summary
- Track hovered tokens and toggle target with **KeyT**
- Display crosshair indicator for targeted tokens and refresh on target changes
- Style wrapper and crosshair for compact overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4e4df9083278c0b3695f46e63f4