### PR TITLE
feat: open token HUD on context menu

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -72,6 +72,11 @@ class PF2ETokenBar {
       img.title = actor.name;
       img.classList.add("pf2e-token-bar-token");
       img.addEventListener("click", () => actor.sheet.render(true));
+      img.addEventListener("contextmenu", event => {
+        event.preventDefault();
+        event.stopPropagation();
+        canvas.hud.token.bind(token); // zeigt das übliche Token-HUD
+      });
       wrapper.appendChild(img);
 
       const hp = actor.system?.attributes?.hp ?? {};


### PR DESCRIPTION
## Summary
- open the token HUD on right-click in the token bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b18937088327850266e45cd8d168