### PR TITLE
Add texture fallback for token images

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -71,8 +71,10 @@ class PF2ETokenBar {
       wrapper.appendChild(indicator);
 
       const img = document.createElement("img");
-      // Token has its texture directly; no `.document` needed
-      img.src = token.texture?.src || "";
+      // Attempt to get the token's texture, falling back to the document's texture
+      const imgSrc = token.texture?.src ?? token.document?.texture?.src ?? "";
+      img.src = imgSrc;
+      if (!imgSrc) console.warn("PF2ETokenBar | token has no texture src", token);
       img.title = actor.name;
       img.classList.add("pf2e-token-bar-token");
       img.addEventListener("click", () => actor.sheet.render(true));


### PR DESCRIPTION
## Summary
- handle missing token textures by falling back to token document texture
- warn when no texture is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ca7db9108327a9f1ae00f0a15f6c