### PR TITLE
Fix effect icon lookup for Token Bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -103,7 +103,7 @@ class PF2ETokenBar {
 
       const effectBar = document.createElement("div");
       effectBar.classList.add("pf2e-effect-bar");
-      const effects = actor.itemTypes?.effect || [];
+      const effects = actor.itemTypes?.effect ?? actor.effects?.contents ?? [];
       for (const effect of effects.filter(e => !e.disabled && !e.isExpired)) {
         const icon = document.createElement("img");
         icon.classList.add("pf2e-effect-icon");


### PR DESCRIPTION
## Summary
- load effect icons from `actor.effects.contents` if `actor.itemTypes.effect` is absent

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ca87de5c8327a98ca2d173a83fdb