### PR TITLE
Use TooltipManager for effect tooltips

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -123,11 +123,13 @@ class PF2ETokenBar {
         icon.classList.add("pf2e-effect-icon");
         icon.src = effect.img;
         icon.dataset.uuid = effect.uuid;
+        icon.title = effect.name;
         icon.addEventListener("mouseenter", async event => {
-          const html = await TextEditor.enrichHTML(`@UUID[${effect.uuid}]{${effect.name}}`, { async: true, documents: true });
-          ui.tooltip?.activate(event.currentTarget, { html });
+          const doc = await fromUuid(icon.dataset.uuid);
+          const html = await TextEditor.enrichHTML(doc.description, { async: true, documents: true, rollData: doc.actor?.getRollData?.() });
+          TooltipManager.shared.show(event.currentTarget, { html });
         });
-        icon.addEventListener("mouseleave", () => ui.tooltip?.deactivate());
+        icon.addEventListener("mouseleave", event => TooltipManager.shared.hide(event.currentTarget));
         icon.addEventListener("click", () => fromUuid(icon.dataset.uuid)?.sheet.render(true));
         icon.addEventListener("contextmenu", async event => {
           event.preventDefault();


### PR DESCRIPTION
## Summary
- add fallback title to effect icons
- enrich effect descriptions and show via TooltipManager

## Testing
- `npm test` *(fails: missing package.json)*
- `node --check scripts/token-bar.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0dd79fb508327a48ff206f8495850