### PR TITLE
Include conditions in PF2e token bar refresh

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -334,13 +334,19 @@ Hooks.on("updateActor", (_actor, data) => {
   if (data.system?.attributes?.hp) PF2ETokenBar.render();
 });
 Hooks.on("createItem", item => {
-  if (item.isOfType?.("effect") || item.type === "effect") PF2ETokenBar.render();
+  const isEffect = item.isOfType?.("effect") || item.type === "effect";
+  const isCondition = item.isOfType?.("condition") || item.type === "condition";
+  if (isEffect || isCondition) PF2ETokenBar.render();
 });
 Hooks.on("deleteItem", item => {
-  if (item.isOfType?.("effect") || item.type === "effect") PF2ETokenBar.render();
+  const isEffect = item.isOfType?.("effect") || item.type === "effect";
+  const isCondition = item.isOfType?.("condition") || item.type === "condition";
+  if (isEffect || isCondition) PF2ETokenBar.render();
 });
 Hooks.on("updateItem", item => {
-  if (item.isOfType?.("effect") || item.type === "effect") PF2ETokenBar.render();
+  const isEffect = item.isOfType?.("effect") || item.type === "effect";
+  const isCondition = item.isOfType?.("condition") || item.type === "condition";
+  if (isEffect || isCondition) PF2ETokenBar.render();
 });
 Hooks.on("renderChatMessage", (_message, html) => {
   const links = html[0]?.querySelectorAll("a.pf2e-token-bar-roll") ?? [];


### PR DESCRIPTION
## Summary
- Re-render token bar when condition items are created, deleted, or updated so effects applied outside the bar are shown

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ed400c688327bec5301cb67ecc11