### PR TITLE
Handle undefined effect UUIDs in tooltip display

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -130,10 +130,12 @@ class PF2ETokenBar {
         const icon = document.createElement("img");
         icon.classList.add("pf2e-effect-icon");
         icon.src = effect.img;
-        icon.dataset.uuid = effect.uuid;
+        const uuid = effect.uuid ?? effect.sourceId;
+        icon.dataset.uuid = uuid;
         icon.title = effect.name;
         icon.addEventListener("mouseenter", async event => {
           const doc = await fromUuid(icon.dataset.uuid);
+          if (!doc) return;
           const description = doc.system?.description?.value ?? "";
           const html = await TextEditor.enrichHTML(description, { async: true, documents: true, rollData: doc.actor?.getRollData?.() });
           if (TooltipManager?.shared) {


### PR DESCRIPTION
## Summary
- Safely resolve effect UUIDs by falling back to `sourceId`
- Avoid undefined descriptions and skip unresolved documents

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f0c94cd4832788afc874f483df0b