### PR TITLE
Remove duplicate uuid declaration in token-bar script

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -131,7 +131,6 @@ class PF2ETokenBar {
         icon.classList.add("pf2e-effect-icon");
         icon.src = effect.img;
         const uuid = effect.uuid ?? effect.sourceId; // Fallback to sourceId when uuid is missing
-        const uuid = effect.uuid ?? effect.sourceId;
         icon.dataset.uuid = uuid;
         icon.title = effect.name;
         icon.addEventListener("mouseenter", async event => {


### PR DESCRIPTION
## Summary
- remove duplicate `uuid` declaration in token bar script

## Testing
- `node --check scripts/token-bar.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0f8af8ba083278d4a38f5b14ec4a5