### PR TITLE
Display effect slugs with tooltips in token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -133,6 +133,9 @@ class PF2ETokenBar {
         const uuid = effect.uuid ?? effect.sourceId; // Fallback to sourceId when uuid is missing
         icon.dataset.uuid = uuid;
         icon.title = effect.name;
+        const slug = document.createElement("span");
+        slug.classList.add("pf2e-effect-slug");
+        slug.textContent = effect.slug;
         icon.addEventListener("mouseenter", async event => {
           const doc = await fromUuid(icon.dataset.uuid);
           if (!doc) return;
@@ -151,6 +154,24 @@ class PF2ETokenBar {
             game.tooltip.deactivate();
           }
         });
+        slug.addEventListener("mouseenter", async event => {
+          const doc = await fromUuid(uuid);
+          if (!doc) return;
+          const description = doc.system?.description?.value ?? "";
+          const html = await TextEditor.enrichHTML(description, { async: true, documents: true, rollData: doc.actor?.getRollData?.() });
+          if (TooltipManager?.shared) {
+            TooltipManager.shared.show(event.currentTarget, { html });
+          } else {
+            game.tooltip.activate(event.currentTarget, html);
+          }
+        });
+        slug.addEventListener("mouseleave", event => {
+          if (TooltipManager?.shared) {
+            TooltipManager.shared.hide(event.currentTarget);
+          } else {
+            game.tooltip.deactivate();
+          }
+        });
         icon.addEventListener("click", () => fromUuid(icon.dataset.uuid)?.sheet.render(true));
         icon.addEventListener("contextmenu", async event => {
           event.preventDefault();
@@ -159,6 +180,7 @@ class PF2ETokenBar {
           PF2ETokenBar.render();
         });
         effectBar.appendChild(icon);
+        effectBar.appendChild(slug);
       }
       wrapper.appendChild(effectBar);
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -59,6 +59,14 @@
   height: 24px;
 }
 
+.pf2e-effect-slug {
+  align-self: center;
+  font-size: 12px;
+  line-height: 24px;
+  color: white;
+  pointer-events: auto;
+}
+
 #pf2e-token-bar .pf2e-bar-handle {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- show each effect's slug next to its icon in the token bar
- allow hovering over slugs to display the same tooltip as icons
- style slugs for visibility and proper hover behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a100fdafc88327b7a4f82453856c29