### PR TITLE
Add combat token support and controls

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -94,3 +94,17 @@
   font-size: 12px;
   display: none;
 }
+
+#pf2e-token-bar .active-turn {
+  outline: 2px solid yellow;
+}
+
+#pf2e-token-bar .pf2e-initiative {
+  position: absolute;
+  top: -6px;
+  left: 0;
+  font-size: 12px;
+  background: rgba(0,0,0,0.7);
+  padding: 0 2px;
+  border-radius: 3px;
+}


### PR DESCRIPTION
## Summary
- Render combat tokens when an encounter is active, showing initiative and highlighting the active turn
- Add navigation controls and combat hooks to refresh the bar on combat events
- Style initiative values and active combatant highlighting

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a20eef5883279e775a8e1af95dfd