### PR TITLE
Add encounter control to token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -201,6 +201,24 @@ class PF2ETokenBar {
     restBtn.addEventListener("click", () => this.restAll());
     content.appendChild(restBtn);
 
+    const encounterBtn = document.createElement("button");
+    encounterBtn.innerText = game.combat?.started ? "End Encounter" : "Start Encounter";
+    encounterBtn.addEventListener("click", async () => {
+      if (game.combat?.started) {
+        await game.combat.endCombat();
+        const party = new Set((game.actors.party?.members ?? []).map(a => a.id));
+        for (const token of canvas.tokens.placeables) {
+          if (!party.has(token.actor?.id)) {
+            await token.document.delete();
+          }
+        }
+      } else {
+        await game.combat?.startCombat();
+      }
+      PF2ETokenBar.render();
+    });
+    content.appendChild(encounterBtn);
+
     if (game.combat?.started) {
       const prevBtn = document.createElement("button");
       prevBtn.innerText = "Prev";


### PR DESCRIPTION
## Summary
- add Start/End Encounter button to token bar controls
- end encounter cleans up non-party tokens and re-renders bar

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa75d82883278e6477b2e7fee4fe