### PR TITLE
Add NPC initiative roll button to token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -202,6 +202,21 @@ class PF2ETokenBar {
     content.appendChild(restBtn);
 
     if (game.combat?.started) {
+      const npcInitBtn = document.createElement("button");
+      npcInitBtn.innerText = "NPC Init";
+      npcInitBtn.addEventListener("click", () => {
+        const ids = game.combat.combatants
+          .filter(c => !c.actor?.hasPlayerOwner && (c.initiative === undefined || c.initiative === null))
+          .map(c => c.id);
+        if (ids.length) game.combat.rollInitiative(ids);
+        npcInitBtn.disabled = true;
+      });
+      const npcCombatants = game.combat.combatants.filter(c => !c.actor?.hasPlayerOwner);
+      if (npcCombatants.length) {
+        npcInitBtn.disabled = npcCombatants.every(c => c.initiative !== undefined && c.initiative !== null);
+        content.appendChild(npcInitBtn);
+      }
+
       const prevBtn = document.createElement("button");
       prevBtn.innerText = "Prev";
       prevBtn.addEventListener("click", () => game.combat.previousTurn());


### PR DESCRIPTION
## Summary
- add an "NPC Init" control to automatically roll initiative for non-player combatants

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa7423c8832782ccccc2c11fc141