### PR TITLE
feat: add initiative roll icon

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -92,6 +92,14 @@ class PF2ETokenBar {
       indicator.style.display = game.user.targets.has(token) ? "block" : "none";
       wrapper.appendChild(indicator);
 
+      const rollIcon = document.createElement("i");
+      rollIcon.classList.add("fas", "fa-dice-d20", "pf2e-roll-icon");
+      rollIcon.addEventListener("click", () => {
+        const combatant = game.combat?.getCombatantByToken(token.id);
+        if (combatant) game.combat.rollInitiative([combatant.id]);
+      });
+      wrapper.appendChild(rollIcon);
+
       const img = document.createElement("img");
       // Attempt to get the token's texture, falling back to the document's texture
       const imgSrc = token.texture?.src ?? token.document?.texture?.src ?? "";

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -108,3 +108,11 @@
   padding: 0 2px;
   border-radius: 3px;
 }
+
+#pf2e-token-bar .pf2e-roll-icon {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add clickable initiative roll icon for each token wrapper
- style roll icon above tokens

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa71ef8083279f73ec38ecf7a899