### PR TITLE
Skip targeting when typing

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -401,6 +401,13 @@ class PF2ETokenBar {
 }
 
 document.addEventListener("keydown", event => {
+  const target = event.target;
+  const isEditable =
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable);
+  if (event.defaultPrevented || isEditable) return;
+
   if (event.code === "KeyT" && PF2ETokenBar.hoveredToken) {
     const token = PF2ETokenBar.hoveredToken;
     token.setTarget(!token.isTargeted, { user: game.user });


### PR DESCRIPTION
## Summary
- Avoid toggling token targeting when the user presses `T` while typing in inputs or content-editable fields
- Honor `defaultPrevented` on keydown events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ae2a4a3483279215eb7613489b21