### PR TITLE
Handle effect icon clicks asynchronously

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -173,7 +173,14 @@ class PF2ETokenBar {
             game.tooltip.deactivate();
           }
         });
-        icon.addEventListener("click", () => fromUuid(uuid)?.sheet.render(true));
+        icon.addEventListener("click", async () => {
+          try {
+            const doc = await fromUuid(uuid);
+            doc?.sheet.render(true);
+          } catch (err) {
+            console.error("PF2ETokenBar | failed to open effect sheet", err);
+          }
+        });
         icon.addEventListener("contextmenu", async event => {
           event.preventDefault();
           event.stopPropagation();


### PR DESCRIPTION
## Summary
- await `fromUuid` when clicking effect icons to ensure sheets open reliably
- add error logging when opening effect sheets fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ae27c40883278980d9c2a729c0e3