### PR TITLE
Add initiative roll icons for combatants

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -84,19 +84,24 @@ class PF2ETokenBar {
         if (PF2ETokenBar.hoveredToken === token) PF2ETokenBar.hoveredToken = null;
       });
 
-      if (game.combat?.started) {
-        const combatant = game.combat.combatants.find(c => c.tokenId === token.id);
-        if (combatant) {
-          if (combatant.id === game.combat.combatant?.id) {
-            wrapper.classList.add("active-turn");
-          }
-          const init = document.createElement("div");
-          init.classList.add("pf2e-initiative");
-          if (combatant.initiative !== undefined && combatant.initiative !== null) {
-            init.innerText = `${combatant.initiative}`;
-          }
-          wrapper.appendChild(init);
+      const combatant = game.combat?.combatants.find(c => c.tokenId === token.id);
+      if (combatant) {
+        const rollIcon = document.createElement("i");
+        rollIcon.classList.add("fas", "fa-dice-d20", "pf2e-d20-icon");
+        rollIcon.addEventListener("click", () => combatant.rollInitiative({ createMessage: true }));
+        wrapper.appendChild(rollIcon);
+      }
+
+      if (game.combat?.started && combatant) {
+        if (combatant.id === game.combat.combatant?.id) {
+          wrapper.classList.add("active-turn");
         }
+        const init = document.createElement("div");
+        init.classList.add("pf2e-initiative");
+        if (combatant.initiative !== undefined && combatant.initiative !== null) {
+          init.innerText = `${combatant.initiative}`;
+        }
+        wrapper.appendChild(init);
       }
 
       const indicator = document.createElement("i");


### PR DESCRIPTION
## Summary
- show a d20 icon for tokens in combat to roll initiative
- keep combat hooks rendering token bar after combatant changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c397ddfc8327a2e2acb2fc0765f9