### PR TITLE
Add combat round display to token bar

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -22,6 +22,7 @@
     "Saves": "Rettungswürfe",
     "Fortitude": "Zähigkeit",
     "Reflex": "Reflexe",
-    "Will": "Willen"
+    "Will": "Willen",
+    "Round": "Runde {round}"
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,7 @@
     "Saves": "Saves",
     "Fortitude": "Fortitude",
     "Reflex": "Reflex",
-    "Will": "Will"
+    "Will": "Will",
+    "Round": "Round {round}"
   }
 }

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -74,6 +74,12 @@ class PF2ETokenBar {
     const content = document.createElement("div");
     content.classList.add("pf2e-token-bar-content");
     bar.appendChild(content);
+    if (game.combat?.round > 0) {
+      const roundDisplay = document.createElement("div");
+      roundDisplay.classList.add("pf2e-round-display");
+      roundDisplay.innerText = game.i18n.format("PF2ETokenBar.Round", { round: game.combat.round });
+      content.prepend(roundDisplay);
+    }
 
     tokens.forEach(token => {
       const actor = token.actor;

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -12,6 +12,11 @@
   gap: 8px;
 }
 
+#pf2e-token-bar .pf2e-round-display {
+  font-weight: bold;
+  margin-right: 4px;
+}
+
 #pf2e-token-bar.collapsed .pf2e-token-bar-content {
   display: none;
 }


### PR DESCRIPTION
## Summary
- show current round at start of token bar when combat is active
- add round translation strings for English and German
- style round counter for emphasis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c3a0941c8327a4961ac92b4727c6