### PR TITLE
Hide heal and rest buttons during encounters

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -216,20 +216,23 @@ class PF2ETokenBar {
 
       content.appendChild(wrapper);
     });
-    const healBtn = document.createElement("button");
-    healBtn.innerText = game.i18n.localize("PF2ETokenBar.HealAll");
-    healBtn.addEventListener("click", () => this.healAll());
-    content.appendChild(healBtn);
-    const btn = document.createElement("button");
-    btn.innerText = game.i18n.localize("PF2ETokenBar.RequestRoll");
-    btn.addEventListener("click", () => this.requestRoll());
-    content.appendChild(btn);
+      if (!game.combat?.started) {
+        const healBtn = document.createElement("button");
+        healBtn.innerText = game.i18n.localize("PF2ETokenBar.HealAll");
+        healBtn.addEventListener("click", () => this.healAll());
+        content.appendChild(healBtn);
 
-    const restBtn = document.createElement("button");
-    restBtn.innerHTML = '<i class="fas fa-bed"></i>';
-    restBtn.title = game.i18n.localize("PF2E.RestAll");
-    restBtn.addEventListener("click", () => this.restAll());
-    content.appendChild(restBtn);
+        const restBtn = document.createElement("button");
+        restBtn.innerHTML = '<i class="fas fa-bed"></i>';
+        restBtn.title = game.i18n.localize("PF2E.RestAll");
+        restBtn.addEventListener("click", () => this.restAll());
+        content.appendChild(restBtn);
+      }
+
+      const btn = document.createElement("button");
+      btn.innerText = game.i18n.localize("PF2ETokenBar.RequestRoll");
+      btn.addEventListener("click", () => this.requestRoll());
+      content.appendChild(btn);
 
     const encounterBtn = document.createElement("button");
     const encounterKey = game.combat?.started ? "PF2ETokenBar.EndEncounter" : "PF2ETokenBar.StartEncounter";


### PR DESCRIPTION
## Summary
- Show Heal All and Rest All controls only when no combat is active
- Keep Request Roll button available at all times

## Testing
- `node --check scripts/token-bar.js`
- `node <<'NODE'
function render(started) {
  const content = { children: [], appendChild(child){ this.children.push(child); } };
  const game = { combat: started ? { started: true } : undefined, i18n: { localize: s => s } };
  const document = { createElement: tag => ({ innerText: '', innerHTML: '', title: '', addEventListener(){}, tag }) };
  const PF2ETokenBar = { healAll(){}, restAll(){}, requestRoll(){} };
  if (!game.combat?.started) {
    const healBtn = document.createElement('button');
    healBtn.innerText = game.i18n.localize('PF2ETokenBar.HealAll');
    healBtn.addEventListener('click', () => PF2ETokenBar.healAll());
    content.appendChild(healBtn);
    const restBtn = document.createElement('button');
    restBtn.innerHTML = '<i class="fas fa-bed"></i>';
    restBtn.title = game.i18n.localize('PF2E.RestAll');
    restBtn.addEventListener('click', () => PF2ETokenBar.restAll());
    content.appendChild(restBtn);
  }
  const btn = document.createElement('button');
  btn.innerText = game.i18n.localize('PF2ETokenBar.RequestRoll');
  btn.addEventListener('click', () => PF2ETokenBar.requestRoll());
  content.appendChild(btn);
  return content.children.map(c => c.innerText || c.innerHTML);
}
console.log('out of combat:', render(false));
console.log('in combat:', render(true));
NODE`
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a1c8b001908327993f076d34e53b7d