### PR TITLE
Use PF2E dialog when rolling initiative

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -94,7 +94,10 @@ class PF2ETokenBar {
       if (combatant) {
         const rollIcon = document.createElement("i");
         rollIcon.classList.add("fas", "fa-dice-d20", "pf2e-d20-icon");
-        rollIcon.addEventListener("click", () => combatant.rollInitiative({ createMessage: true }));
+        rollIcon.addEventListener(
+          "click",
+          () => combatant.actor.initiative?.roll({ createMessage: true, dialog: true })
+        );
         wrapper.appendChild(rollIcon);
       }
 


### PR DESCRIPTION
## Summary
- roll initiative from token bar via PF2E dialog so players can choose Perception or skills

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f69b9a948327b7d908e06051b2f9