### PR TITLE
Add party to encounter button

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -11,6 +11,7 @@
     "RequestRoll": "Wurf anfordern",
     "Roll": "Würfeln",
     "Cancel": "Abbrechen",
+    "AddPartyToEncounter": "Gruppe in Begegnung übernehmen",
     "StartEncounter": "Begegnung starten",
     "EndEncounter": "Begegnung beenden",
     "NPCInit": "NSC-Ini",

--- a/lang/en.json
+++ b/lang/en.json
@@ -11,6 +11,7 @@
     "RequestRoll": "Request Roll",
     "Roll": "Roll",
     "Cancel": "Cancel",
+    "AddPartyToEncounter": "Add Party to Encounter",
     "StartEncounter": "Start Encounter",
     "EndEncounter": "End Encounter",
     "NPCInit": "NPC Init",

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -172,3 +172,7 @@
 #pf2e-token-bar button.npc-initiative:active {
   filter: brightness(0.9);
 }
+
+#pf2e-token-bar button i {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add Add Party to Encounter button before healing and resting
- allow quickly adding party tokens to new combat encounter
- localize button text and ensure icon buttons remain clickable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a226eaf11c8327b66e5c82b9656bce