### PR TITLE
Use arrow icons for turn navigation

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -282,12 +282,20 @@ class PF2ETokenBar {
 
     if (game.combat?.started) {
       const prevBtn = document.createElement("button");
-      prevBtn.innerText = game.i18n.localize("PF2ETokenBar.Prev");
+      prevBtn.classList.add("pf2e-prev-turn");
+      prevBtn.innerHTML = '<i class="fas fa-arrow-left"></i>';
+      const prevTitle = game.i18n.localize("PF2ETokenBar.Prev");
+      prevBtn.title = prevTitle;
+      prevBtn.setAttribute("aria-label", prevTitle);
       prevBtn.addEventListener("click", () => game.combat.previousTurn());
       content.appendChild(prevBtn);
 
       const nextBtn = document.createElement("button");
-      nextBtn.innerText = game.i18n.localize("PF2ETokenBar.Next");
+      nextBtn.classList.add("pf2e-next-turn");
+      nextBtn.innerHTML = '<i class="fas fa-arrow-right"></i>';
+      const nextTitle = game.i18n.localize("PF2ETokenBar.Next");
+      nextBtn.title = nextTitle;
+      nextBtn.setAttribute("aria-label", nextTitle);
       nextBtn.addEventListener("click", () => game.combat.nextTurn());
       content.appendChild(nextBtn);
     }

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -172,3 +172,30 @@
 #pf2e-token-bar button.npc-initiative:active {
   filter: brightness(0.9);
 }
+
+/* Turn navigation buttons */
+#pf2e-token-bar button.pf2e-prev-turn,
+#pf2e-token-bar button.pf2e-next-turn {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 3px;
+  border: 1px solid var(--color-border-dark-primary);
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  cursor: pointer;
+  transition: background 0.1s ease, filter 0.1s ease;
+}
+
+#pf2e-token-bar button.pf2e-prev-turn:hover,
+#pf2e-token-bar button.pf2e-next-turn:hover {
+  filter: brightness(1.2);
+}
+
+#pf2e-token-bar button.pf2e-prev-turn:active,
+#pf2e-token-bar button.pf2e-next-turn:active {
+  filter: brightness(0.9);
+}


### PR DESCRIPTION
## Summary
- replace previous/next combat text buttons with Font Awesome arrow icons
- add hover titles for prev/next and style icon buttons to match the token bar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a226f07c608327ba2d1043967eeb70