### PR TITLE
Use v11 API to add combatants

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -418,7 +418,9 @@ class PF2ETokenBar {
       const exists = combat.combatants.find(c => c.tokenId === token.id);
       if (exists) continue;
       try {
-        await combat.createCombatant({ tokenId: token.id, sceneId: token.scene.id });
+        await combat.createEmbeddedDocuments("Combatant", [
+          { tokenId: token.id, scene: token.scene }
+        ]);
       } catch (err) {
         console.error("PF2ETokenBar | addPartyToEncounter", `failed to add ${actor.id}`, err);
       }


### PR DESCRIPTION
## Summary
- update combatant creation to v11+ API

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22c079a28832793e3cd4a53c19b69