### PR TITLE
Redraw token bar on combatant update

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -101,8 +101,8 @@ class PF2ETokenBar {
         wrapper.appendChild(rollIcon);
       }
 
-      if (game.combat?.started && combatant) {
-        if (combatant.id === game.combat.combatant?.id) {
+      if (combatant) {
+        if (game.combat?.started && combatant.id === game.combat.combatant?.id) {
           wrapper.classList.add("active-turn");
         }
         const init = document.createElement("div");
@@ -543,6 +543,7 @@ Hooks.on("updateCombat", () => PF2ETokenBar.render());
 Hooks.on("combatStart", () => PF2ETokenBar.render());
 Hooks.on("combatEnd", () => PF2ETokenBar.render());
 Hooks.on("combatTurn", () => PF2ETokenBar.render());
+Hooks.on("updateCombatant", () => PF2ETokenBar.render());
 Hooks.on("renderChatMessage", (_message, html) => {
   const links = html[0]?.querySelectorAll("a.pf2e-token-bar-roll") ?? [];
   for (const link of links) {


### PR DESCRIPTION
## Summary
- Show initiative for all combatants and only highlight active turn when combat has started
- Re-render token bar when a combatant is updated

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2315ee1408327bce93b9be9cf1752