### PR TITLE
Preserve tokens when ending encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -249,12 +249,6 @@ class PF2ETokenBar {
     encounterBtn.addEventListener("click", async () => {
       if (game.combat?.started) {
         await game.combat.endCombat();
-        const party = new Set((game.actors.party?.members ?? []).map(a => a.id));
-        for (const token of canvas.tokens.placeables) {
-          if (!party.has(token.actor?.id)) {
-            await token.document.delete();
-          }
-        }
       } else {
         await game.combat?.startCombat();
       }


### PR DESCRIPTION
## Summary
- Stop deleting tokens on encounter end by removing party iteration and deletion loop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d70ec8c8327bca3d2852b09a924