### PR TITLE
Group token bar control buttons

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -219,29 +219,34 @@ class PF2ETokenBar {
 
       content.appendChild(wrapper);
     });
+
+    const controls = document.createElement("div");
+    controls.classList.add("pf2e-token-bar-controls");
+    content.appendChild(controls);
+
       if (!game.combat?.started) {
         const addBtn = document.createElement("button");
         addBtn.innerHTML = '<i class="fas fa-swords"></i>';
         addBtn.title = game.i18n.localize("PF2ETokenBar.AddPartyToEncounter");
         addBtn.addEventListener("click", () => this.addPartyToEncounter());
-        content.appendChild(addBtn);
+        controls.appendChild(addBtn);
 
         const healBtn = document.createElement("button");
         healBtn.innerText = game.i18n.localize("PF2ETokenBar.HealAll");
         healBtn.addEventListener("click", () => this.healAll());
-        content.appendChild(healBtn);
+        controls.appendChild(healBtn);
 
         const restBtn = document.createElement("button");
         restBtn.innerHTML = '<i class="fas fa-bed"></i>';
         restBtn.title = game.i18n.localize("PF2E.RestAll");
         restBtn.addEventListener("click", () => this.restAll());
-        content.appendChild(restBtn);
+        controls.appendChild(restBtn);
       }
 
       const btn = document.createElement("button");
       btn.innerText = game.i18n.localize("PF2ETokenBar.RequestRoll");
       btn.addEventListener("click", () => this.requestRoll());
-      content.appendChild(btn);
+      controls.appendChild(btn);
 
     const encounterBtn = document.createElement("button");
     const encounterKey = game.combat?.started ? "PF2ETokenBar.EndEncounter" : "PF2ETokenBar.StartEncounter";
@@ -260,7 +265,7 @@ class PF2ETokenBar {
       }
       PF2ETokenBar.render();
     });
-    content.appendChild(encounterBtn);
+    controls.appendChild(encounterBtn);
 
     if (game.combat) {
       const npcCombatants = game.combat.combatants.filter(c => !c.actor?.hasPlayerOwner);
@@ -282,7 +287,7 @@ class PF2ETokenBar {
           if (ids.length) await game.combat.rollInitiative(ids);
           PF2ETokenBar.render();
         });
-        content.appendChild(npcInitBtn);
+        controls.appendChild(npcInitBtn);
       }
     }
 
@@ -294,7 +299,7 @@ class PF2ETokenBar {
       prevBtn.title = prevTitle;
       prevBtn.setAttribute("aria-label", prevTitle);
       prevBtn.addEventListener("click", () => game.combat.previousTurn());
-      content.appendChild(prevBtn);
+      controls.appendChild(prevBtn);
 
       const nextBtn = document.createElement("button");
       nextBtn.classList.add("pf2e-next-turn");
@@ -303,7 +308,7 @@ class PF2ETokenBar {
       nextBtn.title = nextTitle;
       nextBtn.setAttribute("aria-label", nextTitle);
       nextBtn.addEventListener("click", () => game.combat.nextTurn());
-      content.appendChild(nextBtn);
+      controls.appendChild(nextBtn);
     }
 
     const toggleBtn = document.createElement("button");

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -12,6 +12,12 @@
   gap: 8px;
 }
 
+#pf2e-token-bar .pf2e-token-bar-controls {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 4px;
+}
+
 #pf2e-token-bar .pf2e-round-display {
   font-weight: bold;
   margin-right: 4px;


### PR DESCRIPTION
## Summary
- group token bar control buttons into dedicated container
- add grid styling for controls container

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d6cfdd88327ba0e214820044894