### PR TITLE
Show initiative die only before rolling

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -91,13 +91,13 @@ class PF2ETokenBar {
       });
 
       const combatant = game.combat?.combatants.find(c => c.tokenId === token.id);
-      if (combatant) {
+      if (combatant && combatant.initiative == null) {
         const rollIcon = document.createElement("i");
         rollIcon.classList.add("fas", "fa-dice-d20", "pf2e-d20-icon");
-        rollIcon.addEventListener(
-          "click",
-          () => combatant.actor.initiative?.roll({ createMessage: true, dialog: true })
-        );
+        rollIcon.addEventListener("click", async () => {
+          await combatant.actor.initiative?.roll({ createMessage: true, dialog: true });
+          PF2ETokenBar.render();
+        });
         wrapper.appendChild(rollIcon);
       }
 


### PR DESCRIPTION
## Summary
- Only display initiative roll die if the combatant has not rolled yet
- Re-render token bar after rolling initiative

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d686b388327acedc5becef657d7