### PR TITLE
Start combat only via encounter button

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -255,7 +255,7 @@ class PF2ETokenBar {
       if (game.combat?.started) {
         await game.combat.endCombat();
       } else {
-        await game.combat?.startCombat();
+        await game.combat.startCombat();
       }
       PF2ETokenBar.render();
     });
@@ -425,7 +425,8 @@ class PF2ETokenBar {
       }
     }
 
-    if (!combat.started) await combat.startCombat();
+    // Removed auto-starting combat; combat should be started manually via the Start Encounter button
+    // if (!combat.started) await combat.startCombat();
     this.render();
   }
 


### PR DESCRIPTION
## Summary
- Remove automatic combat start when adding party to encounter
- Start combat exclusively from the token bar's Start Encounter button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2423a87f48327b6dae1c5f6e40fee