### PR TITLE
Use combat turns for token order

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -356,8 +356,7 @@ class PF2ETokenBar {
     }
 
     static _combatTokens() {
-      const combatants = Array.from(game.combat?.combatants ?? []);
-      combatants.sort((a, b) => (b.initiative ?? 0) - (a.initiative ?? 0));
+      const combatants = Array.from(game.combat?.turns ?? []);
       const tokens = combatants.map(c => canvas.tokens.get(c.tokenId)).filter(t => t);
       this.debug(
         `PF2ETokenBar | _combatTokens found ${tokens.length} tokens`,


### PR DESCRIPTION
## Summary
- Use `game.combat.turns` for combat token retrieval
- Rely on turn order rather than manual initiative sorting

## Testing
- `node -e "global.canvas={tokens:{get:id=>id}};global.game={combat:{turns:[{tokenId:'one',initiative:5},{tokenId:'two',initiative:5}],combatants:[{tokenId:'two',initiative:5},{tokenId:'one',initiative:5}]}};function _combatTokens(){const combatants=Array.from(game.combat?.turns??[]);const tokens=combatants.map(c=>canvas.tokens.get(c.tokenId)).filter(t=>t);return tokens;}console.log(_combatTokens());"`
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2423c7e6c8327948273fdb28d250a