### PR TITLE
Fix missing closing brace in token bar CSS

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -4,7 +4,7 @@
   display: flex;
   gap: 8px;
   padding: 8px;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0, 0, 0, 0.5);
 }
 
 #pf2e-token-bar .pf2e-token-bar-content {
@@ -52,7 +52,7 @@
 #pf2e-token-bar .pf2e-hp-bar {
   width: 100%;
   height: 4px;
-  background: rgba(255,255,255,0.2);
+  background: rgba(255, 255, 255, 0.2);
 }
 
 #pf2e-token-bar .pf2e-hp-bar-inner {
@@ -115,7 +115,7 @@
   top: -6px;
   left: 0;
   font-size: 12px;
-  background: rgba(0,0,0,0.7);
+  background: rgba(0, 0, 0, 0.7);
   padding: 0 2px;
   border-radius: 3px;
 }
@@ -129,7 +129,9 @@
   font-size: 16px;
   color: var(--color-text-light-highlight);
   cursor: pointer;
-  transition: transform 0.1s ease, filter 0.1s ease;
+  transition:
+    transform 0.1s ease,
+    filter 0.1s ease;
 }
 
 #pf2e-token-bar .pf2e-d20-icon:hover {
@@ -149,7 +151,9 @@
   border-radius: 3px;
   border: 1px solid var(--color-border-dark-primary);
   cursor: pointer;
-  transition: background 0.1s ease, filter 0.1s ease;
+  transition:
+    background 0.1s ease,
+    filter 0.1s ease;
 }
 
 #pf2e-token-bar button.start-initiative {
@@ -193,7 +197,9 @@
   background: rgba(0, 0, 0, 0.7);
   color: white;
   cursor: pointer;
-  transition: background 0.1s ease, filter 0.1s ease;
+  transition:
+    background 0.1s ease,
+    filter 0.1s ease;
 }
 
 #pf2e-token-bar button.pf2e-prev-turn:hover,
@@ -204,8 +210,8 @@
 #pf2e-token-bar button.pf2e-prev-turn:active,
 #pf2e-token-bar button.pf2e-next-turn:active {
   filter: brightness(0.9);
+}
 
 #pf2e-token-bar button i {
   pointer-events: none;
-
 }


### PR DESCRIPTION
## Summary
- Add missing closing brace for active turn buttons and ensure button icon block is properly closed
- Format `styles/token-bar.css`

## Testing
- `npx --yes prettier --write styles/token-bar.css`
- `npx --yes csstree-validator styles/token-bar.css && echo 'CSS valid'`

------
https://chatgpt.com/codex/tasks/task_e_68a24738c07883278831b1d6828c1674