### PR TITLE
Show NPCs in token bar without initiative

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -375,7 +375,8 @@ class PF2ETokenBar {
     }
 
     static _combatTokens() {
-      const combatants = Array.from(game.combat?.turns ?? []);
+      let combatants = Array.from(game.combat?.combatants ?? []);
+      combatants.sort((a, b) => (b.initiative ?? -Infinity) - (a.initiative ?? -Infinity));
       const tokens = combatants.map(c => canvas.tokens.get(c.tokenId)).filter(t => t);
       this.debug(
         `PF2ETokenBar | _combatTokens found ${tokens.length} tokens`,


### PR DESCRIPTION
## Summary
- Display combatant tokens even before initiative is rolled by using the combatant list instead of the turn order
- Sort combatants by initiative so tokens with rolled values appear first

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2aad7910c832794fd3e1ed7aee3a5