### PR TITLE
Add loot actor shortcuts to token bar

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -26,6 +26,10 @@
     "Fortitude": "Zähigkeit",
     "Reflex": "Reflexe",
     "Will": "Willen",
-    "Round": "Runde {round}"
+    "Round": "Runde {round}",
+    "PartyStash": "Gruppenlager",
+    "Loot": "Beute",
+    "Sell": "Verkaufen",
+    "TokenMissing": "Token '{name}' nicht gefunden"
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -26,6 +26,10 @@
     "Fortitude": "Fortitude",
     "Reflex": "Reflex",
     "Will": "Will",
-    "Round": "Round {round}"
+    "Round": "Round {round}",
+    "PartyStash": "Party Stash",
+    "Loot": "Loot",
+    "Sell": "Sell",
+    "TokenMissing": "Token '{name}' not found"
   }
 }

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -260,6 +260,21 @@ class PF2ETokenBar {
         restBtn.title = game.i18n.localize("PF2E.RestAll");
         restBtn.addEventListener("click", () => this.restAll());
         controls.appendChild(restBtn);
+
+        const partyStashBtn = document.createElement("button");
+        partyStashBtn.innerText = game.i18n.localize("PF2ETokenBar.PartyStash");
+        partyStashBtn.addEventListener("click", () => PF2ETokenBar.openLootActor("Party Stash"));
+        controls.appendChild(partyStashBtn);
+
+        const lootBtn = document.createElement("button");
+        lootBtn.innerText = game.i18n.localize("PF2ETokenBar.Loot");
+        lootBtn.addEventListener("click", () => PF2ETokenBar.openLootActor("Loot"));
+        controls.appendChild(lootBtn);
+
+        const sellBtn = document.createElement("button");
+        sellBtn.innerText = game.i18n.localize("PF2ETokenBar.Sell");
+        sellBtn.addEventListener("click", () => PF2ETokenBar.openLootActor("Sell"));
+        controls.appendChild(sellBtn);
       }
 
       const btn = document.createElement("button");
@@ -389,6 +404,15 @@ class PF2ETokenBar {
     const tokens = canvas.tokens.placeables.filter(t => t.actor?.hasPlayerOwner);
     this.debug(`PF2ETokenBar | _activePlayerTokens filtered ${tokens.length} tokens`, tokens.map(t => t.actor?.id));
     return tokens;
+  }
+
+  static openLootActor(name) {
+    const actor = game.actors.getName(name);
+    if (actor) {
+      actor.sheet.render(true);
+    } else {
+      ui.notifications.error(game.i18n.format("PF2ETokenBar.TokenMissing", { name }));
+    }
   }
 
   static async restAll() {


### PR DESCRIPTION
## Summary
- add Party Stash, Loot, and Sell buttons to token bar
- implement `openLootActor` utility for opening loot actors
- localize button labels and missing token error

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2afd5d7b483278428cf21f8938cf2