### PR TITLE
feat: show encounter difficulty

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -32,6 +32,14 @@
     "Loot": "Beute",
     "Sell": "Verkaufen",
     "Ping": "Ping",
-    "TokenMissing": "Token '{name}' nicht gefunden"
+    "TokenMissing": "Token '{name}' nicht gefunden",
+    "EncounterDifficulty": "Begegnungsschwierigkeit",
+    "Difficulties": {
+      "Trivial": "Trivial",
+      "Low": "Gering",
+      "Moderate": "Mittel",
+      "Severe": "Schwer",
+      "Extreme": "Extrem"
+    }
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -32,6 +32,14 @@
     "Loot": "Loot",
     "Sell": "Sell",
     "Ping": "Ping",
-    "TokenMissing": "Token '{name}' not found"
+    "TokenMissing": "Token '{name}' not found",
+    "EncounterDifficulty": "Encounter Difficulty",
+    "Difficulties": {
+      "Trivial": "Trivial",
+      "Low": "Low",
+      "Moderate": "Moderate",
+      "Severe": "Severe",
+      "Extreme": "Extreme"
+    }
   }
 }

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -74,6 +74,16 @@ class PF2ETokenBar {
     const content = document.createElement("div");
     content.classList.add("pf2e-token-bar-content");
     bar.appendChild(content);
+
+    const threat = game.combat?.metrics?.threat ?? game.combat?.analyze()?.threat;
+    if (threat) {
+      const difficultyDisplay = document.createElement("div");
+      const capThreat = threat.charAt(0).toUpperCase() + threat.slice(1);
+      difficultyDisplay.classList.add("pf2e-encounter-difficulty", `pf2e-encounter-${threat}`);
+      difficultyDisplay.innerText = game.i18n.localize(`PF2ETokenBar.Difficulties.${capThreat}`);
+      content.prepend(difficultyDisplay);
+    }
+
     if (game.combat?.round > 0) {
       const roundDisplay = document.createElement("div");
       roundDisplay.classList.add("pf2e-round-display");

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -23,6 +23,31 @@
   margin-right: 4px;
 }
 
+#pf2e-token-bar .pf2e-encounter-difficulty {
+  font-weight: bold;
+  margin-right: 4px;
+}
+
+#pf2e-token-bar .pf2e-encounter-trivial {
+  color: turquoise;
+}
+
+#pf2e-token-bar .pf2e-encounter-low {
+  color: green;
+}
+
+#pf2e-token-bar .pf2e-encounter-moderate {
+  color: yellow;
+}
+
+#pf2e-token-bar .pf2e-encounter-severe {
+  color: orange;
+}
+
+#pf2e-token-bar .pf2e-encounter-extreme {
+  color: red;
+}
+
 #pf2e-token-bar.collapsed .pf2e-token-bar-content {
   display: none;
 }


### PR DESCRIPTION
## Summary
- display encounter difficulty in the token bar with color-coded text
- localize difficulty names in English and German

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c76f6a14832792b8766b0b53441f