### PR TITLE
feat: add setting to close combat tracker

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -4,6 +4,10 @@
       "Enabled": {
         "Name": "PF2E Token-Leiste",
         "Hint": "Zeigt die PF2E Token-Leiste an"
+      },
+      "CloseCombatTracker": {
+        "Name": "Standard Kampf-Tracker schließen",
+        "Hint": "Verhindert, dass sich der Standard Kampf-Tracker automatisch öffnet"
       }
     },
     "HealAll": "Alle heilen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,6 +4,10 @@
       "Enabled": {
         "Name": "PF2E Token Bar",
         "Hint": "Show the PF2E Token Bar"
+      },
+      "CloseCombatTracker": {
+        "Name": "Close Combat Tracker",
+        "Hint": "Prevent the standard combat tracker from opening automatically"
       }
     },
     "HealAll": "Heal All",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "pf2e-token-bar",
   "title": "PF2e Token Bar",
   "description": "Displays tokens from the active party and allows roll requests",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "compatibility": {
     "minimum": "13",
     "verified": "13"

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -14,6 +14,14 @@ Hooks.once("init", () => {
     default: true,
     onChange: () => PF2ETokenBar.render()
   });
+  game.settings.register("pf2e-token-bar", "closeCombatTracker", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.CloseCombatTracker.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.CloseCombatTracker.Hint"),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false
+  });
   game.settings.register("pf2e-token-bar", "debug", {
     name: "Debug Logging",
     hint: "Output additional debug information to the console",
@@ -326,6 +334,7 @@ class PF2ETokenBar {
         await game.combat.endCombat();
       } else {
         await game.combat.startCombat();
+        if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker
       }
       PF2ETokenBar.render();
     });


### PR DESCRIPTION
## Summary
- add client setting to close the standard combat tracker when encounters start
- localize new setting in English and German
- bump module version to 2.0.2

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Kazguls-PF2e-Token-Bar/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a2ca45740883279e09c89a76408e6c