### PR TITLE
feat: add radial token context menu

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -26,6 +26,7 @@
     "Hide": "Verbergen",
     "Show": "Anzeigen",
     "Visibility": "Sichtbarkeit umschalten",
+    "Condition": "Zustand",
     "DC": "SG",
     "Saves": "Rettungswürfe",
     "Fortitude": "Zähigkeit",

--- a/lang/en.json
+++ b/lang/en.json
@@ -26,6 +26,7 @@
     "Hide": "Hide",
     "Show": "Show",
     "Visibility": "Toggle Visibility",
+    "Condition": "Condition",
     "DC": "DC",
     "Saves": "Saves",
     "Fortitude": "Fortitude",

--- a/scripts/ring-menu.js
+++ b/scripts/ring-menu.js
@@ -1,0 +1,105 @@
+export class PF2ERingMenu {
+  static element = null;
+  static token = null;
+
+  static open(token, { x, y }) {
+    this.close();
+    this.token = token;
+
+    const menu = document.createElement('div');
+    menu.id = 'pf2e-ring-menu';
+    menu.style.left = `${x}px`;
+    menu.style.top = `${y}px`;
+
+    const items = [];
+
+    // Condition icon
+    const condition = document.createElement('div');
+    condition.classList.add('pf2e-ring-item');
+    condition.title = game.i18n?.localize('PF2ETokenBar.Condition') || 'Condition';
+    condition.innerHTML = '<i class="fas fa-list"></i>';
+    condition.addEventListener('click', async evt => {
+      evt.stopPropagation();
+      await PF2ERingMenu._openConditionMenu(token);
+      PF2ERingMenu.close();
+    });
+    menu.appendChild(condition);
+    items.push(condition);
+
+    // Visibility icon
+    const visibility = document.createElement('div');
+    visibility.classList.add('pf2e-ring-item');
+    visibility.title = game.i18n?.localize('PF2ETokenBar.Visibility') || 'Visibility';
+    const setVisIcon = () => {
+      visibility.innerHTML = token.document.hidden
+        ? '<i class="fas fa-eye-slash"></i>'
+        : '<i class="fas fa-eye"></i>';
+    };
+    setVisIcon();
+    visibility.addEventListener('click', async evt => {
+      evt.stopPropagation();
+      await token.document.update({ hidden: !token.document.hidden });
+      setVisIcon();
+    });
+    menu.appendChild(visibility);
+    items.push(visibility);
+
+    document.body.appendChild(menu);
+
+    // radial placement
+    const radius = 40;
+    const angleStep = (2 * Math.PI) / items.length;
+    items.forEach((item, index) => {
+      const angle = index * angleStep;
+      const size = 32;
+      const left = Math.cos(angle) * radius - size / 2;
+      const top = Math.sin(angle) * radius - size / 2;
+      item.style.left = `${left}px`;
+      item.style.top = `${top}px`;
+    });
+
+    this.element = menu;
+    setTimeout(() => document.addEventListener('mousedown', this._handleOutside, true));
+  }
+
+  static close() {
+    if (this.element) {
+      document.removeEventListener('mousedown', this._handleOutside, true);
+      this.element.remove();
+      this.element = null;
+      this.token = null;
+    }
+  }
+
+  static _handleOutside(event) {
+    if (!PF2ERingMenu.element) return;
+    if (!PF2ERingMenu.element.contains(event.target)) {
+      PF2ERingMenu.close();
+    }
+  }
+
+  static async _openConditionMenu(token) {
+    try {
+      const manager = game.pf2e?.ConditionManager;
+      if (manager) {
+        const conditions = Array.from(manager.conditions.keys()).sort();
+        const options = conditions
+          .map(c => `<option value="${c}">${game.i18n?.localize(manager.conditions.get(c)?.name ?? c) ?? c}</option>`)
+          .join('');
+        const content = `<form><select name="condition">${options}</select></form>`;
+        const slug = await Dialog.prompt({
+          title: game.i18n?.localize('PF2ETokenBar.Condition') || 'Condition',
+          content,
+          label: 'OK',
+          callback: html => html[0].querySelector('[name=condition]').value,
+        });
+        if (slug) await token.actor?.toggleCondition(slug);
+      } else if (token?.hud?.render) {
+        await token.hud.render(true);
+        token.hud.element.find('.status-effects').click();
+      }
+    } catch (err) {
+      console.error('PF2ERingMenu | condition menu error', err);
+    }
+  }
+}

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -1,3 +1,5 @@
+import { PF2ERingMenu } from "./ring-menu.js";
+
 Hooks.once("init", () => {
   game.settings.register("pf2e-token-bar", "position", {
     scope: "client",
@@ -40,6 +42,7 @@ class PF2ETokenBar {
   }
 
   static render() {
+    PF2ERingMenu.close();
     if (!canvas?.ready) return;
     if (!game.user.isGM) return;
     if (!game.settings.get("pf2e-token-bar", "enabled")) {
@@ -189,27 +192,10 @@ class PF2ETokenBar {
       img.title = actor.name;
       img.classList.add("pf2e-token-bar-token");
       img.addEventListener("click", () => actor.sheet.render(true));
-      img.addEventListener("contextmenu", async event => {
+      img.addEventListener("contextmenu", event => {
         event.preventDefault();
         event.stopPropagation();
-        let elem;
-        if (token?.hud?.render) {
-          await token.hud.render(true); // shows the standard Token HUD
-          elem = token.hud.element;
-        } else if (canvas.tokens?.hud?.bind) {
-          await canvas.tokens.hud.bind(token);
-          elem = canvas.tokens.hud.element;
-        } else {
-          await canvas.hud?.token?.bind(token);
-          elem = canvas.hud?.token?.element;
-        }
-
-        if (elem?.css) {
-          elem.css({ left: event.clientX, top: event.clientY });
-        } else if (elem?.style) {
-          elem.style.left = `${event.clientX}px`;
-          elem.style.top = `${event.clientY}px`;
-        }
+        PF2ERingMenu.open(token, { x: event.clientX, y: event.clientY });
       });
       wrapper.appendChild(img);
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -278,3 +278,31 @@
 #pf2e-token-bar button i {
   pointer-events: none;
 }
+
+#pf2e-ring-menu {
+  position: absolute;
+  width: 0;
+  height: 0;
+  z-index: 1000;
+}
+
+#pf2e-ring-menu .pf2e-ring-item {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+#pf2e-ring-menu .pf2e-ring-item:hover {
+  filter: brightness(1.2);
+}
+
+#pf2e-ring-menu .pf2e-ring-item i {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add radial ring menu on token right-click
- allow toggling token visibility and applying conditions
- style ring menu and add localization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d6ca4d748327b17ca2386c89ba61