### PR TITLE
feat: add scrollable token container

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -91,9 +91,19 @@ class PF2ETokenBar {
     handle.classList.add("pf2e-bar-handle");
     handle.innerHTML = '<i class="fas fa-anchor"></i>';
     bar.appendChild(handle);
-    const content = document.createElement("div");
-    content.classList.add("pf2e-token-bar-content");
-    bar.appendChild(content);
+
+    const tokenContainer = document.createElement("div");
+    tokenContainer.classList.add("pf2e-token-bar-content");
+    if (orientation === "vertical") {
+      tokenContainer.style.overflowY = "auto";
+      tokenContainer.style.overflowX = "hidden";
+      tokenContainer.style.maxHeight = "80vh";
+    } else {
+      tokenContainer.style.overflowX = "auto";
+      tokenContainer.style.overflowY = "hidden";
+      tokenContainer.style.maxWidth = "80vw";
+    }
+    bar.appendChild(tokenContainer);
 
     const threat = game.combat?.metrics?.threat ?? game.combat?.analyze()?.threat;
     if (threat) {
@@ -101,14 +111,14 @@ class PF2ETokenBar {
       const capThreat = threat.charAt(0).toUpperCase() + threat.slice(1);
       difficultyDisplay.classList.add("pf2e-encounter-difficulty", `pf2e-encounter-${threat}`);
       difficultyDisplay.innerText = game.i18n.localize(`PF2ETokenBar.Difficulties.${capThreat}`);
-      content.prepend(difficultyDisplay);
+      tokenContainer.prepend(difficultyDisplay);
     }
 
     if (game.combat?.round > 0) {
       const roundDisplay = document.createElement("div");
       roundDisplay.classList.add("pf2e-round-display");
       roundDisplay.innerText = game.i18n.format("PF2ETokenBar.Round", { round: game.combat.round });
-      content.prepend(roundDisplay);
+      tokenContainer.prepend(roundDisplay);
     }
 
     tokens.forEach(token => {
@@ -309,12 +319,12 @@ class PF2ETokenBar {
       }
       wrapper.appendChild(effectBar);
 
-      content.appendChild(wrapper);
+      tokenContainer.appendChild(wrapper);
     });
 
     const controls = document.createElement("div");
     controls.classList.add("pf2e-token-bar-controls");
-    content.appendChild(controls);
+    bar.appendChild(controls);
 
     const orientationBtn = document.createElement("button");
     const updateOrientationBtn = () => {

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -11,10 +11,6 @@
   flex-direction: column;
 }
 
-#pf2e-token-bar.pf2e-token-bar-vertical .pf2e-token-bar-content {
-  flex-direction: column;
-}
-
 #pf2e-token-bar.pf2e-token-bar-vertical .pf2e-token-bar-controls {
   grid-template-columns: repeat(1, auto);
 }
@@ -22,6 +18,16 @@
 #pf2e-token-bar .pf2e-token-bar-content {
   display: flex;
   gap: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 80vw;
+}
+
+#pf2e-token-bar.pf2e-token-bar-vertical .pf2e-token-bar-content {
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 80vh;
 }
 
 #pf2e-token-bar .pf2e-token-bar-controls {


### PR DESCRIPTION
## Summary
- introduce dedicated token container with orientation-based scroll limits
- keep bar controls fixed outside scrollable area
- style token bar content for horizontal and vertical overflow

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30d0984a883279d0d035e08cda67a