### PR TITLE
Manage keydown listener lifecycle

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -674,18 +674,27 @@ class PF2ETokenBar {
   }
 }
 
-document.addEventListener("keydown", event => {
-  const target = event.target;
-  const isEditable =
-    target instanceof HTMLInputElement ||
-    target instanceof HTMLTextAreaElement ||
-    (target instanceof HTMLElement && target.isContentEditable);
-  if (event.defaultPrevented || isEditable) return;
+let keydownListener;
 
-  if (event.code === "KeyT" && PF2ETokenBar.hoveredToken) {
-    const token = PF2ETokenBar.hoveredToken;
-    token.setTarget(!token.isTargeted, { user: game.user });
-  }
+Hooks.once("ready", () => {
+  keydownListener = event => {
+    const target = event.target;
+    const isEditable =
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable);
+    if (event.defaultPrevented || isEditable) return;
+
+    if (event.code === "KeyT" && PF2ETokenBar.hoveredToken) {
+      const token = PF2ETokenBar.hoveredToken;
+      token.setTarget(!token.isTargeted, { user: game.user });
+    }
+  };
+  document.addEventListener("keydown", keydownListener);
+});
+
+Hooks.once("close", () => {
+  if (keydownListener) document.removeEventListener("keydown", keydownListener);
 });
 
 Hooks.on("canvasReady", () => PF2ETokenBar.render());


### PR DESCRIPTION
## Summary
- Register global keydown listener on `Hooks.once('ready')`
- Remove keydown listener on `Hooks.once('close')` to avoid duplicate bindings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a31a6628648327b6fdc9e66658c0b1