### PR TITLE
Allow dragging token bar without separate handle

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -87,10 +87,6 @@ class PF2ETokenBar {
       bar.style.top = "0px";
       bar.style.right = "0px";
     }
-    const handle = document.createElement("div");
-    handle.classList.add("pf2e-bar-handle");
-    handle.innerHTML = '<i class="fas fa-anchor"></i>';
-    bar.appendChild(handle);
 
     const tokenContainer = document.createElement("div");
     tokenContainer.classList.add("pf2e-token-bar-content");
@@ -470,7 +466,8 @@ class PF2ETokenBar {
       game.settings.set("pf2e-token-bar", "position", { top: bar.offsetTop, left: bar.offsetLeft });
     };
 
-    handle.addEventListener("mousedown", event => {
+    bar.addEventListener("mousedown", event => {
+      if (bar.classList.contains("locked")) return;
       event.preventDefault();
       dragging = true;
       offsetX = event.clientX - bar.offsetLeft;

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -7,6 +7,10 @@
   background: rgba(0, 0, 0, 0.5);
 }
 
+#pf2e-token-bar:not(.locked) {
+  cursor: move;
+}
+
 #pf2e-token-bar.pf2e-token-bar-vertical {
   flex-direction: column;
 }
@@ -131,17 +135,6 @@
   width: 24px;
   height: 24px;
 }
-
-#pf2e-token-bar .pf2e-bar-handle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  cursor: move;
-  margin-right: 4px;
-}
-
 #pf2e-token-bar.collapsed .pf2e-effect-bar {
   display: none;
 }


### PR DESCRIPTION
## Summary
- Remove dedicated drag handle element and styling
- Allow dragging the entire bar when unlocked
- Show move cursor on the bar when it isn't locked

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a31e965e3c8327ba5d0a2a1cf80b8d