### PR TITLE
feat: add token bar scaling option

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -8,6 +8,10 @@
       "CloseCombatTracker": {
         "Name": "Standard Kampf-Tracker schließen",
         "Hint": "Verhindert, dass sich der Standard Kampf-Tracker automatisch öffnet"
+      },
+      "Scale": {
+        "Name": "Balkengröße",
+        "Hint": "Größe der Token-Leiste anpassen"
       }
     },
     "HealAll": "Alle heilen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,6 +8,10 @@
       "CloseCombatTracker": {
         "Name": "Close Combat Tracker",
         "Hint": "Prevent the standard combat tracker from opening automatically"
+      },
+      "Scale": {
+        "Name": "Bar Size",
+        "Hint": "Adjust the size of the token bar"
       }
     },
     "HealAll": "Heal All",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -37,6 +37,16 @@ Hooks.once("init", () => {
     type: Boolean,
     default: false
   });
+  game.settings.register("pf2e-token-bar", "scale", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.Scale.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.Scale.Hint"),
+    scope: "client",
+    config: true,
+    type: Number,
+    range: { min: 0.5, max: 2, step: 0.1 },
+    default: 1,
+    onChange: () => PF2ETokenBar.render(),
+  });
   game.settings.register("pf2e-token-bar", "debug", {
     name: "Debug Logging",
     hint: "Output additional debug information to the console",
@@ -83,6 +93,9 @@ class PF2ETokenBar {
     if (bar) bar.remove();
     bar = document.createElement("div");
     bar.id = "pf2e-token-bar";
+    const scale = game.settings.get("pf2e-token-bar", "scale");
+    bar.style.transform = `scale(${scale})`;
+    bar.style.transformOrigin = "top left";
     const orientation = game.settings.get("pf2e-token-bar", "orientation");
     if (orientation === "vertical") bar.classList.add("pf2e-token-bar-vertical");
     const pos = game.settings.get("pf2e-token-bar", "position");

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -5,6 +5,8 @@
   gap: 8px;
   padding: 8px;
   background: rgba(0, 0, 0, 0.5);
+  /* ensure scaling originates from top left */
+  transform-origin: top left;
 }
 
 #pf2e-token-bar:not(.locked) {


### PR DESCRIPTION
## Summary
- allow scaling the token bar through a new user setting
- apply scale when rendering the token bar
- provide translations and CSS support for scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3241943488327ad6d3cf5a8342452