### PR TITLE
Adjust initiative indicator positioning

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -186,11 +186,12 @@
 #pf2e-token-bar .pf2e-initiative {
   position: absolute;
   top: -6px;
-  left: 0;
+  left: 16px;
   font-size: 12px;
   background: rgba(0, 0, 0, 0.7);
   padding: 0 2px;
   border-radius: 3px;
+  z-index: 1;
 }
 
 /* Dice icon positioning */


### PR DESCRIPTION
## Summary
- shift initiative label right to reduce overlap with visibility icon
- give initiative indicator a z-index to avoid being obscured

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a32d7922808327ab4c7e1bf15c4cb9