### PR TITLE
fix: adjust d20 icon positioning

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -197,7 +197,7 @@
 #pf2e-token-bar .pf2e-d20-icon,
 #pf2e-token-bar .pf2e-ping-icon {
   position: absolute;
-  top: -20px;
+  top: 2px;
   left: 50%;
   transform: translateX(-50%);
   font-size: 16px;


### PR DESCRIPTION
## Summary
- prevent the token bar d20 icon from being clipped by placing it within the token's area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a32d79d8c083279ef2f6e9c89e208f