### PR TITLE
Remove unowned combatants after ending encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -426,11 +426,14 @@ class PF2ETokenBar {
     encounterBtn.addEventListener("click", async () => {
       if (game.combat?.started) {
         await game.combat.endCombat();
+        const ids = game.combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
+        if (ids.length) await game.combat.deleteEmbeddedDocuments("Combatant", ids);
+        PF2ETokenBar.render();
       } else {
         await game.combat.startCombat();
         if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker
+        PF2ETokenBar.render();
       }
-      PF2ETokenBar.render();
     });
     controls.appendChild(encounterBtn);
 


### PR DESCRIPTION
## Summary
- Clean up combatants without player ownership when ending an encounter
- Re-render PF2E token bar after combatant removal or combat start

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a32d7af93c832786723cc5a97edf0d