### PR TITLE
Check encounter started before using combat tokens

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -74,7 +74,7 @@ class PF2ETokenBar {
     }
 
     let tokens = [];
-    if (game.combat?.combatants.size > 0) {
+    if (game.combat?.started && game.combat.combatants.size > 0) {
       this.debug("PF2ETokenBar | fetching combat tokens");
       tokens = this._combatTokens();
     } else {


### PR DESCRIPTION
## Summary
- Only use combat token list when the encounter has started

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a32d7bdde08327a3cee081e10db077