### PR TITLE
Separate d20 and ping icon styles

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -195,10 +195,9 @@
 }
 
 /* Dice icon positioning */
-#pf2e-token-bar .pf2e-d20-icon,
-#pf2e-token-bar .pf2e-ping-icon {
+#pf2e-token-bar .pf2e-d20-icon {
   position: absolute;
-  top: 2px;
+  top: -20px;
   left: 50%;
   transform: translateX(-50%);
   font-size: 16px;
@@ -209,14 +208,33 @@
     filter 0.1s ease;
 }
 
-#pf2e-token-bar .pf2e-d20-icon:hover,
-#pf2e-token-bar .pf2e-ping-icon:hover {
+#pf2e-token-bar .pf2e-ping-icon {
+  position: absolute;
+  top: -20px;
+  right: -20px;
+  font-size: 16px;
+  color: var(--color-text-light-highlight);
+  cursor: pointer;
+  transition:
+    transform 0.1s ease,
+    filter 0.1s ease;
+}
+
+#pf2e-token-bar .pf2e-d20-icon:hover {
   transform: translateX(-50%) scale(1.1);
 }
 
-#pf2e-token-bar .pf2e-d20-icon:active,
-#pf2e-token-bar .pf2e-ping-icon:active {
+#pf2e-token-bar .pf2e-ping-icon:hover {
+  transform: scale(1.1);
+}
+
+#pf2e-token-bar .pf2e-d20-icon:active {
   transform: translateX(-50%) scale(0.95);
+  filter: brightness(0.8);
+}
+
+#pf2e-token-bar .pf2e-ping-icon:active {
+  transform: scale(0.95);
   filter: brightness(0.8);
 }
 


### PR DESCRIPTION
## Summary
- Refine token bar dice and ping icons with individual rules for positioning and interactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33235a7f08327afc77fa0cb602554