### PR TITLE
Include combatants pre-combat

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -85,7 +85,14 @@ class PF2ETokenBar {
       tokens = actors
         .map(a => a.getActiveTokens(true)[0])
         .filter(t => t);
+
+      if (game.combat?.combatants.size > 0) {
+        this.debug("PF2ETokenBar | fetching combat tokens");
+        tokens = tokens.concat(this._combatTokens());
+      }
     }
+
+    tokens = [...new Map(tokens.map(t => [t.id, t])).values()];
 
     this.debug("PF2ETokenBar | found tokens", tokens.map(t => t.id));
     if (!tokens.length) return;


### PR DESCRIPTION
## Summary
- include combatants in token bar before combat starts
- de-duplicate tokens by id when merging party and combat lists

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3348b76408327a09cc83860a883ea