### PR TITLE
Reposition visibility toggle icon

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -189,23 +189,6 @@ class PF2ETokenBar {
         wrapper.appendChild(init);
       }
 
-      const visibilityIcon = document.createElement("i");
-      visibilityIcon.classList.add(
-        "fas",
-        token.document.hidden ? "fa-eye-slash" : "fa-eye",
-        "pf2e-visibility-icon"
-      );
-      const visibilityTitle = game.i18n.localize("PF2ETokenBar.Visibility");
-      visibilityIcon.title = visibilityTitle;
-      visibilityIcon.setAttribute("aria-label", visibilityTitle);
-      visibilityIcon.addEventListener("click", async () => {
-        await token.document.update({ hidden: !token.document.hidden });
-        wrapper.classList.toggle("pf2e-token-hidden", token.document.hidden);
-        visibilityIcon.classList.toggle("fa-eye", !token.document.hidden);
-        visibilityIcon.classList.toggle("fa-eye-slash", token.document.hidden);
-      });
-      wrapper.appendChild(visibilityIcon);
-
       const indicator = document.createElement("i");
       indicator.classList.add("fas", "fa-crosshairs", "target-indicator");
       indicator.style.display = game.user.targets.has(token) ? "block" : "none";
@@ -233,6 +216,23 @@ class PF2ETokenBar {
         PF2ERingMenu.open(token, { x: event.clientX, y: event.clientY });
       });
       wrapper.appendChild(img);
+
+      const visibilityIcon = document.createElement("i");
+      visibilityIcon.classList.add(
+        "fas",
+        token.document.hidden ? "fa-eye-slash" : "fa-eye",
+        "pf2e-visibility-icon"
+      );
+      const visibilityTitle = game.i18n.localize("PF2ETokenBar.Visibility");
+      visibilityIcon.title = visibilityTitle;
+      visibilityIcon.setAttribute("aria-label", visibilityTitle);
+      visibilityIcon.addEventListener("click", async () => {
+        await token.document.update({ hidden: !token.document.hidden });
+        wrapper.classList.toggle("pf2e-token-hidden", token.document.hidden);
+        visibilityIcon.classList.toggle("fa-eye", !token.document.hidden);
+        visibilityIcon.classList.toggle("fa-eye-slash", token.document.hidden);
+      });
+      wrapper.appendChild(visibilityIcon);
 
       const hp = actor.system?.attributes?.hp ?? {};
       const hpValue = Number(hp.value) || 0;

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -169,10 +169,11 @@
 
 .pf2e-visibility-icon {
   position: absolute;
-  top: 2px;
-  left: 2px;
+  top: -20px;
+  left: -20px;
   font-size: 12px;
   cursor: pointer;
+  z-index: 3;
 }
 
 .pf2e-token-hidden img.pf2e-token-bar-token {


### PR DESCRIPTION
## Summary
- move visibility toggle icon away from token and raise z-index
- append visibility toggle after token image so it appears above

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3348a2e6483278d343b5ae7ea3432