### PR TITLE
Center initiative label above token

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -187,10 +187,13 @@
 #pf2e-token-bar .pf2e-initiative {
   position: absolute;
   top: -6px;
-  left: 16px;
+  left: 50%;
+  transform: translateX(-50%);
   font-size: 12px;
   background: rgba(0, 0, 0, 0.7);
   padding: 0 2px;
+  min-width: 20px;
+  text-align: center;
   border-radius: 3px;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- center initiative label over each token using `left: 50%` and translate transform
- ensure label has minimum width and centered text to fit two-digit initiative values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33874b1948327b34179b04b12a279