### PR TITLE
Refactor token bar icons to ring menu

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -41,6 +41,7 @@
     "Loot": "Beute",
     "Sell": "Verkaufen",
     "Ping": "Ping",
+    "Initiative": "Initiative",
     "Vertical": "Vertikal",
     "Horizontal": "Horizontal",
     "Lock": "Sperren",

--- a/lang/en.json
+++ b/lang/en.json
@@ -41,6 +41,7 @@
     "Loot": "Loot",
     "Sell": "Sell",
     "Ping": "Ping",
+    "Initiative": "Initiative",
     "Vertical": "Vertical",
     "Horizontal": "Horizontal",
     "Lock": "Lock",

--- a/scripts/ring-menu.js
+++ b/scripts/ring-menu.js
@@ -44,6 +44,33 @@ export class PF2ERingMenu {
     menu.appendChild(visibility);
     items.push(visibility);
 
+    // Ping icon
+    const ping = document.createElement('div');
+    ping.classList.add('pf2e-ring-item');
+    ping.title = game.i18n?.localize('PF2ETokenBar.Ping') || 'Ping';
+    ping.innerHTML = '<i class="fas fa-bullseye"></i>';
+    ping.addEventListener('click', evt => {
+      evt.stopPropagation();
+      canvas.ping(token.center, { user: game.user });
+    });
+    menu.appendChild(ping);
+    items.push(ping);
+
+    // Initiative icon
+    const combatant = game.combat?.combatants.find(c => c.tokenId === token.id);
+    if (combatant && combatant.initiative == null) {
+      const initiative = document.createElement('div');
+      initiative.classList.add('pf2e-ring-item');
+      initiative.title = game.i18n?.localize('PF2ETokenBar.Initiative') || 'Initiative';
+      initiative.innerHTML = '<i class="fas fa-dice-d20"></i>';
+      initiative.addEventListener('click', async evt => {
+        evt.stopPropagation();
+        await combatant.actor.initiative.roll({ createMessage: true, dialog: true });
+      });
+      menu.appendChild(initiative);
+      items.push(initiative);
+    }
+
     document.body.appendChild(menu);
 
     // radial placement

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -155,15 +155,6 @@ class PF2ETokenBar {
       });
 
       const combatant = game.combat?.combatants.find(c => c.tokenId === token.id);
-      if (combatant && combatant.initiative == null) {
-        const rollIcon = document.createElement("i");
-        rollIcon.classList.add("fas", "fa-dice-d20", "pf2e-d20-icon");
-        rollIcon.addEventListener("click", async () => {
-          await combatant.actor.initiative?.roll({ createMessage: true, dialog: true });
-          PF2ETokenBar.render();
-        });
-        wrapper.appendChild(rollIcon);
-      }
 
       if (combatant) {
         const delayed = combatant.getFlag("pf2e-token-bar", "delayed");
@@ -201,14 +192,6 @@ class PF2ETokenBar {
       indicator.style.display = game.user.targets.has(token) ? "block" : "none";
       wrapper.appendChild(indicator);
 
-      const pingIcon = document.createElement("i");
-      pingIcon.classList.add("fas", "fa-bullseye", "pf2e-ping-icon");
-      const pingTitle = game.i18n.localize("PF2ETokenBar.Ping");
-      pingIcon.title = pingTitle;
-      pingIcon.setAttribute("aria-label", pingTitle);
-      pingIcon.addEventListener("click", () => canvas.ping(token.center, { user: game.user }));
-      wrapper.appendChild(pingIcon);
-
       const img = document.createElement("img");
       // Attempt to get the token's texture, falling back to the document's texture
       const imgSrc = token.texture?.src ?? token.document?.texture?.src ?? "";
@@ -223,23 +206,6 @@ class PF2ETokenBar {
         PF2ERingMenu.open(token, { x: event.clientX, y: event.clientY });
       });
       wrapper.appendChild(img);
-
-      const visibilityIcon = document.createElement("i");
-      visibilityIcon.classList.add(
-        "fas",
-        token.document.hidden ? "fa-eye-slash" : "fa-eye",
-        "pf2e-visibility-icon"
-      );
-      const visibilityTitle = game.i18n.localize("PF2ETokenBar.Visibility");
-      visibilityIcon.title = visibilityTitle;
-      visibilityIcon.setAttribute("aria-label", visibilityTitle);
-      visibilityIcon.addEventListener("click", async () => {
-        await token.document.update({ hidden: !token.document.hidden });
-        wrapper.classList.toggle("pf2e-token-hidden", token.document.hidden);
-        visibilityIcon.classList.toggle("fa-eye", !token.document.hidden);
-        visibilityIcon.classList.toggle("fa-eye-slash", token.document.hidden);
-      });
-      wrapper.appendChild(visibilityIcon);
 
       const hp = actor.system?.attributes?.hp ?? {};
       const hpValue = Number(hp.value) || 0;

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -167,15 +167,6 @@
   display: none;
 }
 
-.pf2e-visibility-icon {
-  position: absolute;
-  top: -20px;
-  left: -20px;
-  font-size: 12px;
-  cursor: pointer;
-  z-index: 3;
-}
-
 .pf2e-token-hidden img.pf2e-token-bar-token {
   opacity: 0.4;
 }
@@ -193,50 +184,6 @@
   padding: 0 2px;
   border-radius: 3px;
   z-index: 1;
-}
-
-/* Dice icon positioning */
-#pf2e-token-bar .pf2e-d20-icon {
-  position: absolute;
-  top: -20px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 16px;
-  color: var(--color-text-light-highlight);
-  cursor: pointer;
-  transition:
-    transform 0.1s ease,
-    filter 0.1s ease;
-}
-
-#pf2e-token-bar .pf2e-ping-icon {
-  position: absolute;
-  top: -20px;
-  right: -20px;
-  font-size: 16px;
-  color: var(--color-text-light-highlight);
-  cursor: pointer;
-  transition:
-    transform 0.1s ease,
-    filter 0.1s ease;
-}
-
-#pf2e-token-bar .pf2e-d20-icon:hover {
-  transform: translateX(-50%) scale(1.1);
-}
-
-#pf2e-token-bar .pf2e-ping-icon:hover {
-  transform: scale(1.1);
-}
-
-#pf2e-token-bar .pf2e-d20-icon:active {
-  transform: translateX(-50%) scale(0.95);
-  filter: brightness(0.8);
-}
-
-#pf2e-token-bar .pf2e-ping-icon:active {
-  transform: scale(0.95);
-  filter: brightness(0.8);
 }
 
 #pf2e-token-bar .pf2e-delay-icon,


### PR DESCRIPTION
## Summary
- remove inline ping, visibility, and initiative icons from the token bar
- add Ping and Initiative actions to the token context ring menu
- drop unused icon styles and add translation for Initiative

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3387597a88327825a0edc03ba4092