### PR TITLE
Position initiative badge above token

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -178,8 +178,8 @@
 #pf2e-token-bar .pf2e-initiative {
   position: absolute;
   top: -6px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  transform: none;
   font-size: 12px;
   background: rgba(0, 0, 0, 0.7);
   padding: 0 2px;


### PR DESCRIPTION
## Summary
- Reposition initiative badge above token's left edge to avoid overlap

## Testing
- `npm test` *(fails: package.json not found)*
- `node - <<'NODE'
const { createCanvas } = require('/tmp/canvas/node_modules/canvas');
function measure(text) {
  const canvas = createCanvas(200, 50);
  const ctx = canvas.getContext('2d');
  ctx.font = '12px sans-serif';
  const metrics = ctx.measureText(text);
  const width = metrics.width + 4; // padding 0 2px
  return width;
}
console.log('single digit width', measure('9'));
console.log('double digit width', measure('10'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a33bf484288327be93af1d1a5a1bac