### PR TITLE
feat: add delay toggle ring menu

### DIFF
--- a/scripts/ring-menu.js
+++ b/scripts/ring-menu.js
@@ -56,8 +56,27 @@ export class PF2ERingMenu {
     menu.appendChild(ping);
     items.push(ping);
 
-    // Initiative icon
     const combatant = game.combat?.combatants.find(c => c.tokenId === token.id);
+    if (combatant) {
+      const delayed = combatant.getFlag("pf2e-token-bar", "delayed");
+      const delay = document.createElement('div');
+      delay.classList.add('pf2e-ring-item');
+      const delayKey = delayed ? 'PF2ETokenBar.Play' : 'PF2ETokenBar.Delay';
+      delay.title = game.i18n?.localize(delayKey) || (delayed ? 'Play' : 'Delay');
+      delay.innerHTML = delayed ? '<i class="fas fa-play"></i>' : '<i class="fas fa-hourglass"></i>';
+      delay.addEventListener('click', async evt => {
+        evt.stopPropagation();
+        if (delayed) {
+          await PF2ETokenBar.resumeTurn(combatant);
+        } else {
+          await PF2ETokenBar.delayTurn(combatant);
+        }
+      });
+      menu.appendChild(delay);
+      items.push(delay);
+    }
+
+    // Initiative icon
     if (combatant && combatant.initiative == null) {
       const initiative = document.createElement('div');
       initiative.classList.add('pf2e-ring-item');

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -592,6 +592,8 @@ class PF2ETokenBar {
     if (!combatant || !game.combat) return;
     try {
       await combatant.setFlag("pf2e-token-bar", "delayed", true);
+      const token = combatant.token?.object;
+      await token?.document.update({ overlayEffect: "icons/svg/hourglass.svg" });
       await game.combat.nextTurn();
     } catch (err) {
       console.error("PF2ETokenBar | delayTurn", err);
@@ -606,6 +608,8 @@ class PF2ETokenBar {
       const init = current?.initiative;
       if (init !== undefined) await game.combat.setInitiative(combatant.id, init);
       await combatant.unsetFlag("pf2e-token-bar", "delayed");
+      const token = combatant.token?.object;
+      await token?.document.update({ overlayEffect: null });
       const index = game.combat.turns.findIndex(c => c.id === combatant.id);
       if (index >= 0) await game.combat.update({ turn: index });
     } catch (err) {


### PR DESCRIPTION
## Summary
- add ring menu option to delay and resume a combatant's turn
- show hourglass overlay when delaying turns and remove it when resuming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a345b4994c83278202ec7acb0d00db