### PR TITLE
Add party stash shortcut

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -48,6 +48,7 @@
     "Unlock": "Entsperren",
     "HeroPoints": "Heldenpunkte",
     "TokenMissing": "Token '{name}' nicht gefunden",
+    "PartySheetMissing": "Gruppenblatt nicht gefunden",
     "EncounterDifficulty": "Begegnungsschwierigkeit",
     "Difficulties": {
       "Trivial": "Trivial",

--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,7 @@
     "Unlock": "Unlock",
     "HeroPoints": "Hero Points",
     "TokenMissing": "Token '{name}' not found",
+    "PartySheetMissing": "Party Sheet not found",
     "EncounterDifficulty": "Encounter Difficulty",
     "Difficulties": {
       "Trivial": "Trivial",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -368,7 +368,7 @@ class PF2ETokenBar {
 
         const partyStashBtn = document.createElement("button");
         partyStashBtn.innerText = game.i18n.localize("PF2ETokenBar.PartyStash");
-        partyStashBtn.addEventListener("click", () => PF2ETokenBar.openLootActor("Party Stash"));
+        partyStashBtn.addEventListener("click", () => PF2ETokenBar.openPartyStash());
         controls.appendChild(partyStashBtn);
 
         const lootBtn = document.createElement("button");
@@ -519,6 +519,16 @@ class PF2ETokenBar {
     const tokens = canvas.tokens.placeables.filter(t => t.actor?.hasPlayerOwner);
     this.debug(`PF2ETokenBar | _activePlayerTokens filtered ${tokens.length} tokens`, tokens.map(t => t.actor?.id));
     return tokens;
+  }
+
+  static openPartyStash() {
+    const sheet = game.pf2e.apps.partySheet;
+    if (sheet) {
+      sheet.render(true);
+      sheet.setTab("stash");
+    } else {
+      ui.notifications.error(game.i18n.localize("PF2ETokenBar.PartySheetMissing"));
+    }
   }
 
   static openLootActor(name) {


### PR DESCRIPTION
## Summary
- open Party Stash via the party sheet tab
- add translation for missing party sheet error

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/token-bar.js`

------
https://chatgpt.com/codex/tasks/task_e_68a34d8efd68832784a7c70544387820