### PR TITLE
fix: safeguard party sheet access

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -522,7 +522,7 @@ class PF2ETokenBar {
   }
 
   static openPartyStash() {
-    const sheet = game.pf2e.apps.partySheet;
+    const sheet = game.pf2e.party?.sheet ?? game.pf2e.apps?.partySheet;
     if (sheet) {
       sheet.render(true);
       sheet.setTab("stash");


### PR DESCRIPTION
## Summary
- safely resolve PF2E party sheet when opening party stash

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36cd555f08327bcd8cb81e597021c