### PR TITLE
Ensure combatant creation sets actor and scene IDs

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -585,9 +585,11 @@ class PF2ETokenBar {
       const exists = combat.combatants.find(c => c.tokenId === token.id);
       if (exists) continue;
       try {
-        await combat.createEmbeddedDocuments("Combatant", [
-          { tokenId: token.id, scene: token.scene }
-        ]);
+        await combat.createEmbeddedDocuments("Combatant", [{
+          tokenId: token.id,
+          actorId: actor.id,
+          sceneId: token.scene.id
+        }]);
       } catch (err) {
         console.error("PF2ETokenBar | addPartyToEncounter", `failed to add ${actor.id}`, err);
       }


### PR DESCRIPTION
## Summary
- include `actorId` and `sceneId` when adding party members to an encounter
- stop using deprecated `scene` property for combatants

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a36cee054c832791465ed3e042dcbb