### PR TITLE
Mark party combatants as players when added

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -588,7 +588,8 @@ class PF2ETokenBar {
         await combat.createEmbeddedDocuments("Combatant", [{
           tokenId: token.id,
           actorId: actor.id,
-          sceneId: token.scene.id
+          sceneId: token.scene.id,
+          alliance: "party"
         }]);
       } catch (err) {
         console.error("PF2ETokenBar | addPartyToEncounter", `failed to add ${actor.id}`, err);


### PR DESCRIPTION
## Summary
- include `alliance: "party"` when adding party members to a combat

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37227137c8327b80b313a2bc91c2c