### PR TITLE
Sort NPCs before PCs at equal initiative

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -506,7 +506,13 @@ class PF2ETokenBar {
 
     static _combatTokens() {
       let combatants = Array.from(game.combat?.combatants ?? []);
-      combatants.sort((a, b) => (b.initiative ?? -Infinity) - (a.initiative ?? -Infinity));
+      combatants.sort((a, b) => {
+        const diff = (b.initiative ?? -Infinity) - (a.initiative ?? -Infinity);
+        if (diff !== 0) return diff;
+        const aIsPlayer = a.actor?.hasPlayerOwner ? 1 : 0;
+        const bIsPlayer = b.actor?.hasPlayerOwner ? 1 : 0;
+        return aIsPlayer - bIsPlayer;   // NPCs (0) vor PCs (1)
+      });
       const tokens = combatants.map(c => canvas.tokens.get(c.tokenId)).filter(t => t);
       this.debug(
         `PF2ETokenBar | _combatTokens found ${tokens.length} tokens`,


### PR DESCRIPTION
## Summary
- Prefer NPCs over PCs when initiatives tie in combat token bar

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `zip -r pf2e-token-bar.zip README.md module.json lang scripts styles`


------
https://chatgpt.com/codex/tasks/task_e_68a37d6b219883279d87b7e55a66065b