### PR TITLE
feat: add compendium button

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -40,6 +40,7 @@
     "PartyStash": "Gruppenlager",
     "Loot": "Beute",
     "Sell": "Verkaufen",
+    "Compendium": "Kompendium",
     "Ping": "Ping",
     "Initiative": "Initiative",
     "Vertical": "Vertikal",

--- a/lang/en.json
+++ b/lang/en.json
@@ -40,6 +40,7 @@
     "PartyStash": "Party Stash",
     "Loot": "Loot",
     "Sell": "Sell",
+    "Compendium": "Compendium",
     "Ping": "Ping",
     "Initiative": "Initiative",
     "Vertical": "Vertical",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -348,6 +348,13 @@ class PF2ETokenBar {
     });
     controls.appendChild(lockBtn);
 
+    const compendiumBtn = document.createElement("button");
+    compendiumBtn.innerHTML = '<i class="fas fa-book"></i>';
+    compendiumBtn.title = game.i18n.localize("PF2ETokenBar.Compendium");
+    compendiumBtn.setAttribute("aria-label", compendiumBtn.title);
+    compendiumBtn.addEventListener("click", () => ui.sidebar.activateTab("compendium"));
+    controls.appendChild(compendiumBtn);
+
       if (!game.combat?.started) {
         const addBtn = document.createElement("button");
         addBtn.innerHTML = '<i class="fas fa-swords"></i>';


### PR DESCRIPTION
## Summary
- add compendium button with book icon to token bar
- localize compendium label in English and German

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a381af75f88327bfb4a6d8464be788