### PR TITLE
Remove compendium button from token bar

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -40,7 +40,6 @@
     "PartyStash": "Gruppenlager",
     "Loot": "Beute",
     "Sell": "Verkaufen",
-    "Compendium": "Kompendium",
     "Ping": "Ping",
     "Initiative": "Initiative",
     "Vertical": "Vertikal",

--- a/lang/en.json
+++ b/lang/en.json
@@ -40,7 +40,6 @@
     "PartyStash": "Party Stash",
     "Loot": "Loot",
     "Sell": "Sell",
-    "Compendium": "Compendium",
     "Ping": "Ping",
     "Initiative": "Initiative",
     "Vertical": "Vertical",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -348,14 +348,7 @@ class PF2ETokenBar {
     });
     controls.appendChild(lockBtn);
 
-    const compendiumBtn = document.createElement("button");
-    compendiumBtn.innerHTML = '<i class="fas fa-book"></i>';
-    compendiumBtn.title = game.i18n.localize("PF2ETokenBar.Compendium");
-    compendiumBtn.setAttribute("aria-label", compendiumBtn.title);
-    compendiumBtn.addEventListener("click", () => ui.sidebar.activateTab("compendium"));
-    controls.appendChild(compendiumBtn);
-
-      if (!game.combat?.started) {
+    if (!game.combat?.started) {
         const addBtn = document.createElement("button");
         addBtn.innerHTML = '<i class="fas fa-swords"></i>';
         addBtn.title = game.i18n.localize("PF2ETokenBar.AddPartyToEncounter");


### PR DESCRIPTION
## Summary
- remove the Compendium button from the token bar controls
- drop unused "Compendium" localization keys from English and German

## Testing
- `npm test` *(fails: Could not read package.json)*
- `rg -n "Compendium" -g "*"`


------
https://chatgpt.com/codex/tasks/task_e_68a390ce20d48327a265e58d04922d61