### PR TITLE
Fix party stash tab activation

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -534,11 +534,11 @@ class PF2ETokenBar {
     return tokens;
   }
 
-  static openPartyStash() {
+  static async openPartyStash() {
     const sheet = game.pf2e.party?.sheet ?? game.pf2e.apps?.partySheet;
     if (sheet) {
-      sheet.render(true);
-      sheet.setTab("stash");
+      await sheet.render(true);
+      sheet._tabs[0]?.activate("stash");
     } else {
       ui.notifications.error(game.i18n.localize("PF2ETokenBar.PartySheetMissing"));
     }


### PR DESCRIPTION
## Summary
- ensure party stash opens on the stash tab by awaiting render and activating the tab directly

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a390e568308327bef16e838991d468