### PR TITLE
Expose PF2ETokenBar globally

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -708,6 +708,8 @@ class PF2ETokenBar {
   }
 }
 
+globalThis.PF2ETokenBar = PF2ETokenBar;
+
 let keydownListener;
 
 Hooks.once("ready", () => {


### PR DESCRIPTION
## Summary
- Make PF2ETokenBar available on `globalThis` so other scripts can access it

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3991e7b388327b2f0e932b221d119