### PR TITLE
fix: iterate condition slugs for ring menu

### DIFF
--- a/scripts/ring-menu.js
+++ b/scripts/ring-menu.js
@@ -128,11 +128,15 @@ export class PF2ERingMenu {
     try {
       const manager = game.pf2e?.ConditionManager;
       if (manager) {
-        const conditions = Array.from(manager.conditions.values())
-          .map(c => ({ slug: c.slug, name: game.i18n.localize(c.name) }))
+        const conditions = manager.conditionsSlugs
+          .map(slug => {
+            const condition = manager.conditions.get(slug);
+            const name = game.i18n.localize(condition?.name ?? slug);
+            return { slug, name };
+          })
           .sort((a, b) => a.name.localeCompare(b.name));
         const options = conditions
-          .map(c => `<option value="${c.slug}">${c.name}</option>`)
+          .map(({ slug, name }) => `<option value="${slug}">${name}</option>`)
           .join('');
         const content = `<form><select name="condition">${options}</select></form>`;
         const slug = await Dialog.prompt({


### PR DESCRIPTION
## Summary
- build condition menu from `manager.conditionsSlugs`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a39be8cba483278f86149d1e83feb9