### PR TITLE
Use party macro to open stash

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -527,11 +527,10 @@ class PF2ETokenBar {
     return tokens;
   }
 
-  static async openPartyStash() {
-    const sheet = game.pf2e.party?.sheet ?? game.pf2e.apps?.partySheet;
-    if (sheet) {
-      await sheet.render(true);
-      sheet._tabs[0]?.activate("stash");
+  static openPartyStash() {
+    const party = game.actors.party;
+    if (party?.sheet) {
+      party.sheet.render(true, { tab: "inventory" });
     } else {
       ui.notifications.error(game.i18n.localize("PF2ETokenBar.PartySheetMissing"));
     }


### PR DESCRIPTION
## Summary
- open the party stash by rendering the Party actor's inventory tab
- keep button wired to `openPartyStash`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a417c139888327ba242a481e743671