### PR TITLE
fix: display initiative values

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -29,8 +29,9 @@
   display: flex;
   gap: 8px;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: visible;
   max-width: 80vw;
+  padding-top: 8px;
 }
 
 #pf2e-token-bar.pf2e-token-bar-vertical .pf2e-token-bar-content {
@@ -38,6 +39,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   max-height: 80vh;
+  padding-top: 8px;
 }
 
 #pf2e-token-bar .pf2e-token-bar-controls {


### PR DESCRIPTION
## Summary
- fix token bar content overflow to allow initiative values to show
- add padding-top to token bar content in vertical and horizontal layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a42fc3394483278001ea1491e7c214