### PR TITLE
Safely delete combat in encounter button

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -390,23 +390,28 @@ class PF2ETokenBar {
     const encounterBtn = document.createElement("button");
     const encounterKey = game.combat?.started ? "PF2ETokenBar.EndEncounter" : "PF2ETokenBar.StartEncounter";
     encounterBtn.innerText = game.i18n.localize(encounterKey);
-      encounterBtn.addEventListener("click", async () => {
+    encounterBtn.addEventListener("click", async () => {
+      try {
         if (game.combat?.started) {
-          await game.combat.endCombat();
-          const ids = game.combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
-          if (ids.length) await game.combat.deleteEmbeddedDocuments("Combatant", ids);
+          const combat = game.combat;
+          await combat.endCombat();
+          const ids = combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
+          if (ids.length) await combat.deleteEmbeddedDocuments("Combatant", ids);
 
-          const combatants = Array.from(game.combat.combatants);
+          const combatants = Array.from(combat.combatants);
           await Promise.all(combatants.map(c => c.unsetFlag("pf2e-token-bar", "delayed")));
 
-          await game.combat.delete();
-          PF2ETokenBar.render();
+          if (game.combats.has(combat.id)) await combat.delete();
         } else {
           await game.combat.startCombat();
           if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker
-          PF2ETokenBar.render();
         }
-      });
+      } catch (error) {
+        console.error(error);
+      } finally {
+        PF2ETokenBar.render();
+      }
+    });
     controls.appendChild(encounterBtn);
 
     if (game.combat) {


### PR DESCRIPTION
## Summary
- Guard encounter handling with try/catch/finally to ensure token bar rerenders
- Cache combat reference and check collection before deleting

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a43485d9a48327aafc8fbde89ebbe3