### PR TITLE
Ensure combat is re-fetched before deletion

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -401,7 +401,8 @@ class PF2ETokenBar {
           const combatants = Array.from(combat.combatants);
           await Promise.all(combatants.map(c => c.unsetFlag("pf2e-token-bar", "delayed")));
 
-          if (game.combats.has(combat.id)) await combat.delete();
+          const current = await fromUuid(combat.uuid);
+          if (current) await current.delete();
         } else {
           await game.combat.startCombat();
           if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker


### PR DESCRIPTION
## Summary
- Re-fetch combat via `fromUuid` before deleting during encounter end
- Remove obsolete `game.combats.has` check

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4384426c08327bcb1b378ad832b13