### PR TITLE
Delete combat directly when ending encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -400,9 +400,7 @@ class PF2ETokenBar {
 
           const combatants = Array.from(combat.combatants);
           await Promise.all(combatants.map(c => c.unsetFlag("pf2e-token-bar", "delayed")));
-
-          const current = await fromUuid(combat.uuid);
-          if (current) await current.delete();
+          await combat.delete();
         } else {
           await game.combat.startCombat();
           if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker


### PR DESCRIPTION
## Summary
- Directly delete combat at encounter end

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a443c31bcc8327a9eaed8a9e6bf213