### PR TITLE
fix encounter cleanup

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -395,12 +395,14 @@ class PF2ETokenBar {
         if (game.combat?.started) {
           const combat = game.combat;
           await combat.endCombat();
-          const ids = combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
-          if (ids.length) await combat.deleteEmbeddedDocuments("Combatant", ids);
 
           const combatants = Array.from(combat.combatants);
           await Promise.all(combatants.map(c => c.unsetFlag("pf2e-token-bar", "delayed")));
-          await combat.delete();
+
+          const ids = combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
+          if (ids.length) await combat.deleteEmbeddedDocuments("Combatant", ids);
+
+          if (game.combats.has(combat.id)) await combat.delete();
         } else {
           await game.combat.startCombat();
           if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker


### PR DESCRIPTION
## Summary
- ensure flags cleared before removing NPC combatants
- delete combat only if it still exists

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44919931083278296d3188db04e7f