### PR TITLE
Avoid deleting combat when ending encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -572,7 +572,6 @@ class PF2ETokenBar {
     await combat.endCombat();
     const npcIds = combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
     if (npcIds.length) await combat.deleteEmbeddedDocuments("Combatant", npcIds);
-    if (game.combats.has(combat.id)) await combat.delete();
     PF2ETokenBar.render();
   }
 


### PR DESCRIPTION
## Summary
- remove combat deletion from `endEncounter` to prevent errors after concluding combat

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a46087827c8327a02a7fd8016a2556