### PR TITLE
Fix NPC removal when ending encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -569,9 +569,9 @@ class PF2ETokenBar {
   static async endEncounter() {
     const combat = game.combat;
     if (!combat) return;
-    await combat.endCombat();
     const npcIds = combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
     if (npcIds.length) await combat.deleteEmbeddedDocuments("Combatant", npcIds);
+    await combat.endCombat();
     PF2ETokenBar.render();
   }
 


### PR DESCRIPTION
## Summary
- remove NPC combatants before ending encounter to prevent errors

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check scripts/token-bar.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4633b049483279c957ce1baade6dd