### PR TITLE
Ensure active combat exists before adding party

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -580,7 +580,7 @@ class PF2ETokenBar {
     if (!actors.length) return;
 
     let combat = game.combat;
-    if (!combat) {
+    if (!combat || !game.combats.has(combat.id)) {
       try {
         combat = await Combat.create({ scene: canvas.scene });
       } catch (err) {


### PR DESCRIPTION
## Summary
- Verify an active combat exists before adding party members, creating a new combat if needed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4667f304883278488681830c50c72