### PR TITLE
Use combat.delete to fully end encounters

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -569,9 +569,7 @@ class PF2ETokenBar {
   static async endEncounter() {
     const combat = game.combat;
     if (!combat) return;
-    const npcIds = combat.combatants.filter(c => !c.actor?.hasPlayerOwner).map(c => c.id);
-    if (npcIds.length) await combat.deleteEmbeddedDocuments("Combatant", npcIds);
-    await combat.endCombat();
+    await combat.delete();
     PF2ETokenBar.render();
   }
 


### PR DESCRIPTION
## Summary
- Delete the active combat instead of calling `endCombat` to drop the token bar back to party mode
- Remove NPC combatant cleanup now handled by combat deletion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4667e2f3c83278486ba3aa154696d