### PR TITLE
Use combat started flag for token bar mode switching

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -81,7 +81,7 @@ class PF2ETokenBar {
       .map(a => a.getActiveTokens(true)[0])
       .filter(t => t);
 
-    if (game.combat?.combatants.size > 0) {
+    if (game.combat?.started) {
       this.debug("PF2ETokenBar | fetching combat tokens");
       tokens = tokens.concat(this._combatTokens());
     }


### PR DESCRIPTION
## Summary
- use `game.combat.started` instead of checking combatants count to include combat tokens only in active combat

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4667fb050832792306b181cd8b0b4