### PR TITLE
Ensure combat exists before starting encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -395,7 +395,13 @@ class PF2ETokenBar {
         if (game.combat?.started) {
           await PF2ETokenBar.endEncounter();
         } else {
-          await game.combat.startCombat();
+          let combat = game.combat;
+          if (!combat || !game.combats.has(combat.id)) {
+            combat = await Combat.create({ scene: canvas.scene });
+            game.combat = combat;
+            await PF2ETokenBar.addPartyToEncounter();
+          }
+          await combat.startCombat();
           if (game.settings.get("pf2e-token-bar", "closeCombatTracker")) ui.combat?.close(); // prevents automatic opening of the standard combat tracker
           PF2ETokenBar.render();
         }


### PR DESCRIPTION
## Summary
- ensure encountering code creates a new combat when none exists before starting

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: enoent: no package.json)*
- node simulation verifying new combat created and startCombat called

------
https://chatgpt.com/codex/tasks/task_e_68a46ba67cac8327b1331ae6970f4ee1