### PR TITLE
Fix combat deletion to avoid missing combat warning

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -569,7 +569,8 @@ class PF2ETokenBar {
   static async endEncounter() {
     const combat = game.combat;
     if (!combat) return;
-    await combat.delete();
+    await combat.endCombat();
+    game.combat = null;
     PF2ETokenBar.render();
   }
 


### PR DESCRIPTION
## Summary
- use `endCombat` and reset `game.combat` instead of deleting combat

## Testing
- `node --check scripts/token-bar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a46ba8e1108327b0669208004fec20