### PR TITLE
Delete combat when ending encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -575,8 +575,9 @@ class PF2ETokenBar {
   static async endEncounter() {
     const combat = game.combat;
     if (!combat) return;
-    await combat.endCombat();
-    game.combat = null;
+    if (game.combats.has(combat.id)) {
+      await Combat.deleteDocuments([combat.id]);
+    }
     PF2ETokenBar.render();
   }
 


### PR DESCRIPTION
## Summary
- Remove manual `game.combat` nulling and delete combat document if it exists
- Render the token bar after ending an encounter for UI refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f2d34ac8327b6412181a534cb39