### PR TITLE
Use local combat variable when adding party to encounter

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -598,10 +598,10 @@ class PF2ETokenBar {
     for (const actor of actors) {
       const token = actor.getActiveTokens(true)[0];
       if (!token) continue;
-      const exists = game.combat.combatants.find(c => c.tokenId === token.id);
+      const exists = combat.combatants.find(c => c.tokenId === token.id);
       if (exists) continue;
       try {
-        await game.combat.createEmbeddedDocuments("Combatant", [{
+        await combat.createEmbeddedDocuments("Combatant", [{
           tokenId: token.id,
           actorId: actor.id,
           sceneId: token.scene.id,


### PR DESCRIPTION
## Summary
- Use the locally determined combat object when adding party members to an encounter
- Keep render call after adding all combatants

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f34d6808327b1a8564e5646b545