### PR TITLE
Load combat tokens when combatants exist

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -83,9 +83,9 @@ class PF2ETokenBar {
       .map(a => a.getActiveTokens(true)[0])
       .filter(t => t);
 
-    if (activeCombat?.started) {
+    if (activeCombat?.combatants.size) {
       this.debug("PF2ETokenBar | fetching combat tokens");
-      tokens = tokens.concat(this._combatTokens());
+      tokens = this._combatTokens();
     }
 
     tokens = [...new Map(tokens.map(t => [t.id, t])).values()];


### PR DESCRIPTION
## Summary
- Use combat tokens whenever a combat has any combatants
- Avoid merging party tokens with combat tokens to prevent duplicate entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4745cbc3c8327b9587c707e578248