### PR TITLE
Adjust resumeTurn initiative to follow current turn

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -627,7 +627,7 @@ class PF2ETokenBar {
     try {
       const current = game.combat.combatant;
       const init = current?.initiative;
-      if (init !== undefined) await game.combat.setInitiative(combatant.id, init);
+      if (init !== undefined) await game.combat.setInitiative(combatant.id, init - 1);
       await combatant.unsetFlag("pf2e-token-bar", "delayed");
       const token = combatant.token?.object;
       await token?.document.update({ overlayEffect: null });


### PR DESCRIPTION
## Summary
- subtract 1 from current initiative when resuming a delayed turn so combatant acts immediately after current

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4794923788327b818a84cc651df9e