### PR TITLE
fix: expand top padding for token bar

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -3,7 +3,7 @@
   top: 0;
   display: flex;
   gap: 8px;
-  padding: 8px;
+  padding: 20px 8px 8px 8px;
   background: rgba(0, 0, 0, 0.5);
   /* ensure scaling originates from top left */
   transform-origin: top left;


### PR DESCRIPTION
## Summary
- expand token bar padding to prevent delay icon from clipping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47b30968c8327bf07a55ccc794dee