### PR TITLE
fix: keep delay/play icons within token bar

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -194,7 +194,7 @@
 #pf2e-token-bar .pf2e-delay-icon,
 #pf2e-token-bar .pf2e-play-icon {
   position: absolute;
-  top: -20px;
+  top: -8px;
   left: 50%;
   transform: translateX(-50%);
   font-size: 16px;


### PR DESCRIPTION
## Summary
- reposition delay/play icons to stay within token bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4837fb2bc8327ba495c5efedca4cb