### PR TITLE
Add drag-and-drop support to token bar buttons

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -297,6 +297,10 @@
   pointer-events: none;
 }
 
+#pf2e-token-bar button.pf2e-drop-hover {
+  filter: brightness(1.2);
+}
+
 #pf2e-ring-menu {
   position: absolute;
   width: 0;


### PR DESCRIPTION
## Summary
- allow dropping items onto Party Stash, Loot, and Sell buttons
- handle dropped item data and permissions
- highlight buttons on dragover for visual feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57ebe3b3c8327b30d293fe0f1894e