### PR TITLE
Remove source item after drag-and-drop

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -633,11 +633,17 @@ class PF2ETokenBar {
       const item = await fromUuid(parsed.uuid);
       if (!(item instanceof Item)) throw new Error("Item not found");
 
+      const sourceActor = item.actor;
+
       const actor = target === "party" ? game.actors.party : game.actors.getName(target);
       if (!actor) throw new Error(game.i18n.format("PF2ETokenBar.TokenMissing", { name: target }));
       if (!actor.isOwner) throw new Error("You do not have permission to modify this actor.");
 
+      if (sourceActor && sourceActor === actor) return;
+
       await actor.createEmbeddedDocuments("Item", [item.toObject()]);
+
+      if (sourceActor && sourceActor !== actor) await item.delete();
     } catch (err) {
       console.error(err);
       ui.notifications.error(err.message || "Failed to drop item.");


### PR DESCRIPTION
## Summary
- Delete an item's original copy when dropping it onto another actor
- Avoid redundant copy when source and target actors match

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b3486ad883278a1a38383cd304a6