### PR TITLE
Match token tab CSS size with JavaScript constant

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -350,7 +350,7 @@
 
 .pf2e-token-tab{
   position:absolute;
-  width:24px;height:24px;
+  width:16px;height:16px;
   border-radius:50%;
   background:rgba(0,0,0,0.8);
   color:white;display:flex;


### PR DESCRIPTION
## Summary
- Reduce `.pf2e-token-tab` width and height to 16px to align with the JavaScript `size` setting.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b7090e5c8327b5c8d8ef55fbf78b