### PR TITLE
Adjust token tab layout and size

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -256,10 +256,10 @@ class PF2ETokenBar {
       wrapper.appendChild(proficiencyTab);
       icons.push(proficiencyTab);
 
-      const size = 24;
-      const radius = Math.max(40, size / (2 * Math.sin(Math.PI / icons.length)));
+      const size = 16;
+      const radius = 48;
       icons.forEach((icon, i) => {
-        const ang = (i / icons.length) * 2 * Math.PI;
+        const ang = Math.PI + (i + 0.5) * Math.PI / icons.length;
         icon.style.left = `${32 + Math.cos(ang) * radius - size / 2}px`;
         icon.style.top = `${32 + Math.sin(ang) * radius - size / 2}px`;
       });

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -350,7 +350,7 @@
 
 .pf2e-token-tab{
   position:absolute;
-  width:24px;height:24px;
+  width:16px;height:16px;
   border-radius:50%;
   background:rgba(0,0,0,0.8);
   color:white;display:flex;


### PR DESCRIPTION
## Summary
- reposition token tabs to lower semicircle and avoid covering tokens
- shrink token tab icons to match new layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b70ac73c832785c2d3131b4e0a6a