### PR TITLE
Refactor token tabs layout

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -212,7 +212,9 @@ class PF2ETokenBar {
       });
       wrapper.appendChild(img);
 
-      const icons = [];
+      const tabContainer = document.createElement("div");
+      tabContainer.classList.add("pf2e-token-tabs");
+      wrapper.appendChild(tabContainer);
 
       const actionTab = document.createElement("div");
       actionTab.classList.add("pf2e-token-tab");
@@ -223,8 +225,7 @@ class PF2ETokenBar {
       actionTab.title = actionsTitle;
       actionTab.setAttribute("aria-label", actionsTitle);
       actionTab.addEventListener("click", () => actor.sheet.render(true, { tab: "actions" }));
-      wrapper.appendChild(actionTab);
-      icons.push(actionTab);
+      tabContainer.appendChild(actionTab);
 
       const spellTab = document.createElement("div");
       spellTab.classList.add("pf2e-token-tab");
@@ -233,8 +234,7 @@ class PF2ETokenBar {
       spellTab.title = spellsTitle;
       spellTab.setAttribute("aria-label", spellsTitle);
       spellTab.addEventListener("click", () => actor.sheet.render(true, { tab: "spellcasting" }));
-      wrapper.appendChild(spellTab);
-      icons.push(spellTab);
+      tabContainer.appendChild(spellTab);
 
       const inventoryTab = document.createElement("div");
       inventoryTab.classList.add("pf2e-token-tab");
@@ -243,8 +243,7 @@ class PF2ETokenBar {
       inventoryTab.title = inventoryTitle;
       inventoryTab.setAttribute("aria-label", inventoryTitle);
       inventoryTab.addEventListener("click", () => actor.sheet.render(true, { tab: "inventory" }));
-      wrapper.appendChild(inventoryTab);
-      icons.push(inventoryTab);
+      tabContainer.appendChild(inventoryTab);
 
       const proficiencyTab = document.createElement("div");
       proficiencyTab.classList.add("pf2e-token-tab");
@@ -253,16 +252,7 @@ class PF2ETokenBar {
       proficiencyTab.title = proficiencyTitle;
       proficiencyTab.setAttribute("aria-label", proficiencyTitle);
       proficiencyTab.addEventListener("click", () => actor.sheet.render(true, { tab: "proficiencies" }));
-      wrapper.appendChild(proficiencyTab);
-      icons.push(proficiencyTab);
-
-      const size = 16;
-      const radius = 48;
-      icons.forEach((icon, i) => {
-        const ang = Math.PI + (i + 0.5) * Math.PI / icons.length;
-        icon.style.left = `${32 + Math.cos(ang) * radius - size / 2}px`;
-        icon.style.top = `${32 + Math.sin(ang) * radius - size / 2}px`;
-      });
+      tabContainer.appendChild(proficiencyTab);
 
       const hp = actor.system?.attributes?.hp ?? {};
       const hpValue = Number(hp.value) || 0;

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -127,6 +127,7 @@
   width: 100%;
   height: 4px;
   background: rgba(255, 255, 255, 0.2);
+  margin-top: 2px;
 }
 
 #pf2e-token-bar .pf2e-hp-bar-inner {
@@ -156,6 +157,7 @@
 .pf2e-effect-bar {
   display: flex;
   gap: 3px;
+  margin-top: 2px;
 }
 
 .pf2e-effect-icon {
@@ -349,7 +351,6 @@
 }
 
 .pf2e-token-tab{
-  position:absolute;
   width:16px;height:16px;
   border-radius:50%;
   background:rgba(0,0,0,0.8);
@@ -358,3 +359,10 @@
   cursor:pointer;
 }
 .pf2e-token-tab:hover{filter:brightness(1.2);}
+
+.pf2e-token-tabs {
+  display:flex;
+  gap:4px;
+  justify-content:center;
+  margin-top:4px;
+}


### PR DESCRIPTION
## Summary
- Move action, spell, inventory, and proficiency tabs into new pf2e-token-tabs container
- Lay out token tabs with flexbox and adjust HP/effect bar spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c06cc47c8327acf50b528374a5c0