### PR TITLE
Replace action tab icon with glyph

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -218,9 +218,10 @@ class PF2ETokenBar {
 
       const actionTab = document.createElement("div");
       actionTab.classList.add("pf2e-token-tab");
-      const actionImg = document.createElement("img");
-      actionImg.src = "systems/pf2e/icons/actions/SingleAction.webp";
-      actionTab.appendChild(actionImg);
+      const actionGlyph = document.createElement("span");
+      actionGlyph.classList.add("action-glyph");
+      actionGlyph.textContent = "1";
+      actionTab.appendChild(actionGlyph);
       const actionsTitle = game.i18n.localize("PF2ETokenBar.Actions");
       actionTab.title = actionsTitle;
       actionTab.setAttribute("aria-label", actionsTitle);

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -358,6 +358,10 @@
   align-items:center;justify-content:center;
   cursor:pointer;
 }
+.pf2e-token-tab .action-glyph {
+  font-size: 16px;
+  line-height: 16px;
+}
 .pf2e-token-tab:hover{filter:brightness(1.2);}
 
 .pf2e-token-tabs {


### PR DESCRIPTION
## Summary
- replace single action tab image with glyph
- add styling for action glyph

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a5c3be39c08327b5fde4c3bfc5f239