### PR TITLE
Add dynamic HP bar color based on health percentage

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -269,6 +269,12 @@ class PF2ETokenBar {
       const barInner = document.createElement("div");
       barInner.classList.add("pf2e-hp-bar-inner");
       const pct = hpMax > 0 ? Math.min(Math.max((hpValue / hpMax) * 100, 0), 100) : 0;
+      const color =
+        pct > 75 ? "green" :
+        pct > 50 ? "yellow" :
+        pct > 25 ? "orange" :
+        "red";
+      barInner.style.backgroundColor = color;
       barInner.style.width = `${pct}%`;
       barOuter.appendChild(barInner);
       wrapper.appendChild(barOuter);

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -132,7 +132,6 @@
 
 #pf2e-token-bar .pf2e-hp-bar-inner {
   height: 100%;
-  background: red;
 }
 
 #pf2e-token-bar .pf2e-hero-points {


### PR DESCRIPTION
## Summary
- Colorize HP bar based on remaining health
- Allow JS to control HP bar color by removing fixed CSS background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c7f16b7083279eba6d7df54853cb