### PR TITLE
feat: gold border for hero points

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -151,7 +151,7 @@
 #pf2e-token-bar .pf2e-hero-point {
   width: 16px;
   height: 16px;
-  border: 1px solid var(--color-border-dark-primary);
+  border: 1px solid gold;
   border-radius: 50%;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- use gold border color on empty hero point indicators to match filled points

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ce3297048327938e64dd3b845d2f