### PR TITLE
feat: enable token item drops

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -149,6 +149,12 @@ class PF2ETokenBar {
       wrapper.addEventListener("mouseleave", () => {
         if (PF2ETokenBar.hoveredToken === token) PF2ETokenBar.hoveredToken = null;
       });
+      wrapper.addEventListener("dragover", event => {
+        event.preventDefault();
+        wrapper.classList.add("pf2e-drop-hover");
+      });
+      wrapper.addEventListener("dragleave", () => wrapper.classList.remove("pf2e-drop-hover"));
+      wrapper.addEventListener("drop", event => PF2ETokenBar.handleItemDrop(event, actor));
 
       const combatant = activeCombat?.combatants.find(c => c.tokenId === token.id);
 
@@ -628,7 +634,11 @@ class PF2ETokenBar {
 
       const sourceActor = item.actor;
 
-      const actor = target === "party" ? game.actors.party : game.actors.getName(target);
+      const actor = target && typeof target === "object"
+        ? target
+        : target === "party"
+          ? game.actors.party
+          : game.actors.getName(target);
       if (!actor) throw new Error(game.i18n.format("PF2ETokenBar.TokenMissing", { name: target }));
       if (!actor.isOwner) throw new Error("You do not have permission to modify this actor.");
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -125,6 +125,10 @@
   position: relative;
 }
 
+#pf2e-token-bar .pf2e-token-wrapper.pf2e-drop-hover {
+  filter: brightness(1.2);
+}
+
 #pf2e-token-bar .pf2e-hp-text {
   font-size: 12px;
   line-height: 1;


### PR DESCRIPTION
## Summary
- support dropping items directly on token bar tokens
- allow handleItemDrop to accept Actor objects
- highlight tokens during dragover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d125b89883279f031ef05622f6bb