### PR TITLE
feat: add partyOnlySelf setting

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -12,6 +12,10 @@
       "Scale": {
         "Name": "Balkengröße",
         "Hint": "Größe der Token-Leiste anpassen"
+      },
+      "PartyOnlySelf": {
+        "Name": "Nur eigener Charakter",
+        "Hint": "Wenn du kein SL bist, werden nur Tokens von Charakteren angezeigt, die du besitzt"
       }
     },
     "HealAll": "Alle heilen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -12,6 +12,10 @@
       "Scale": {
         "Name": "Bar Size",
         "Hint": "Adjust the size of the token bar"
+      },
+      "PartyOnlySelf": {
+        "Name": "Show Only Owned Tokens",
+        "Hint": "When not a GM, show only tokens for actors you own"
       }
     },
     "HealAll": "Heal All",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -55,6 +55,15 @@ Hooks.once("init", () => {
     type: Boolean,
     default: false
   });
+  game.settings.register("pf2e-token-bar", "partyOnlySelf", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.PartyOnlySelf.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.PartyOnlySelf.Hint"),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: () => PF2ETokenBar.render(),
+  });
 });
 
 class PF2ETokenBar {
@@ -562,7 +571,11 @@ class PF2ETokenBar {
 
     static _partyTokens() {
       if (game.combat?.started) return [];
-      const actors = game.actors.party?.members || [];
+      let actors = game.actors.party?.members || [];
+      if (game.settings.get("pf2e-token-bar", "partyOnlySelf") && !game.user.isGM) {
+        const userChar = game.user.character;
+        actors = actors.filter(a => (userChar && a.id === userChar.id) || a.isOwner);
+      }
       this.debug(
         `PF2ETokenBar | _partyTokens found ${actors.length} actors`,
         actors.map(a => a.id)


### PR DESCRIPTION
## Summary
- add `partyOnlySelf` setting to allow clients to show only their own tokens
- filter party tokens according to new setting
- localize new setting in English and German

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d57559dc83278c10d23249f570c3