### PR TITLE
Limit token bar width and scroll to active token

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -127,7 +127,10 @@ class PF2ETokenBar {
     } else {
       tokenContainer.style.overflowX = "auto";
       tokenContainer.style.overflowY = "hidden";
-      tokenContainer.style.maxWidth = "80vw";
+      const tokenWidth = 64;
+      const gap = 12;
+      const maxWidth = (tokenWidth + gap) * 8;
+      tokenContainer.style.setProperty("--token-bar-max-width", `${maxWidth}px`);
     }
     bar.appendChild(tokenContainer);
 
@@ -898,7 +901,12 @@ Hooks.on("updateItem", item => {
 Hooks.on("updateCombat", () => PF2ETokenBar.render());
 Hooks.on("combatStart", () => PF2ETokenBar.render());
 Hooks.on("combatEnd", () => PF2ETokenBar.render());
-Hooks.on("combatTurn", () => PF2ETokenBar.render());
+Hooks.on("combatTurn", () => {
+  PF2ETokenBar.render();
+  document
+    .querySelector("#pf2e-token-bar .active-turn")
+    ?.scrollIntoView({ behavior: "smooth", inline: "center" });
+});
 Hooks.on("updateCombatant", () => PF2ETokenBar.render());
 Hooks.on("renderChatMessage", (_message, html) => {
   const links = html[0]?.querySelectorAll("a.pf2e-token-bar-roll") ?? [];

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -30,7 +30,7 @@
   gap: 12px;
   overflow-x: auto;
   overflow-y: visible;
-  max-width: 80vw;
+  max-width: var(--token-bar-max-width, 80vw);
   padding-top: 8px;
 }
 


### PR DESCRIPTION
## Summary
- Limit token bar's horizontal width to eight tokens using CSS variable
- Auto-scroll to the current combatant when turns change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ddbf84188327947da979d674cff5