### PR TITLE
Prevent token wrapper shrink

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -123,6 +123,7 @@
   flex-direction: column;
   align-items: center;
   position: relative;
+  flex-shrink: 0;
 }
 
 #pf2e-token-bar .pf2e-token-wrapper.pf2e-drop-hover {


### PR DESCRIPTION
## Summary
- Add `flex-shrink: 0` to each token wrapper so tokens maintain their width when the bar scrolls horizontally.
- Ensure token bar content retains `overflow-x: auto` for horizontal scrolling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ee4b40a083278ea889009510c819