### PR TITLE
feat: add quick loot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ Under **Settings → Module Settings → PF2e Token-Bar**:
 - **Close default combat tracker** – prevents auto-opening of Foundry’s combat tracker.  
 - **Bar size** – scale between 50% and 200%.  
 - **Orientation** – horizontal or vertical (also via button on the bar).  
-- **Lock bar** – prevents accidental moving.  
+- **Lock bar** – prevents accidental moving.
 - **Position** – automatically saved after moving.
+- **Quick loot** – automatically transfer defeated NPC loot and open the Loot actor when combat ends.
 
 ---
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -16,6 +16,10 @@
       "PartyOnlySelf": {
         "Name": "Nur eigener Charakter",
         "Hint": "Wenn du kein SL bist, werden nur Tokens von Charakteren angezeigt, die du besitzt"
+      },
+      "QuickLoot": {
+        "Name": "Schnellbeute",
+        "Hint": "Überträgt nach dem Kampf automatisch die Beute besiegter NSC und öffnet den Beute-Akteur."
       }
     },
     "HealAll": "Alle heilen",

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,6 +16,10 @@
       "PartyOnlySelf": {
         "Name": "Show Only Owned Tokens",
         "Hint": "When not a GM, show only tokens for actors you own"
+      },
+      "QuickLoot": {
+        "Name": "Quick Loot",
+        "Hint": "Automatically transfer defeated NPC loot and open the Loot actor on combat end."
       }
     },
     "HealAll": "Heal All",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -64,6 +64,14 @@ Hooks.once("init", () => {
     default: false,
     onChange: () => PF2ETokenBar.render(),
   });
+  game.settings.register("pf2e-token-bar", "quickLoot", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.QuickLoot.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.QuickLoot.Hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
 });
 
 class PF2ETokenBar {
@@ -943,8 +951,10 @@ Hooks.on("updateCombat", () => PF2ETokenBar.render());
 Hooks.on("combatStart", () => PF2ETokenBar.render());
 Hooks.on("combatEnd", async () => {
   PF2ETokenBar.render();
-  await PF2ETokenBar.transferDefeatedLoot();
-  PF2ETokenBar.openLootActor("Loot");
+  if (game.user.isGM && game.settings.get("pf2e-token-bar", "quickLoot")) {
+    await PF2ETokenBar.transferDefeatedLoot();
+    PF2ETokenBar.openLootActor("Loot");
+  }
 });
 Hooks.on("combatTurn", () => {
   PF2ETokenBar.render();


### PR DESCRIPTION
## Summary
- add `quickLoot` module setting to auto-transfer loot after combat
- gate combat end loot transfer behind GM permission and setting
- document and localize quick loot option

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60099476483279b3779e1645e429b