### PR TITLE
feat: confirm quick loot after combat

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -22,6 +22,8 @@
         "Hint": "Überträgt nach dem Kampf automatisch die Beute besiegter NSC und öffnet den Beute-Akteur."
       }
     },
+    "QuickLootConfirmTitle": "Schnellbeute",
+    "QuickLootConfirmContent": "Beute besiegter NSC übertragen und Beute-Akteur öffnen?",
     "HealAll": "Alle heilen",
     "HealAllConfirm": "Alle auf volle HP setzen?",
     "RequestRoll": "Wurf anfordern",

--- a/lang/en.json
+++ b/lang/en.json
@@ -22,6 +22,8 @@
         "Hint": "Automatically transfer defeated NPC loot and open the Loot actor on combat end."
       }
     },
+    "QuickLootConfirmTitle": "Quick Loot",
+    "QuickLootConfirmContent": "Transfer defeated NPC loot and open the Loot actor?",
     "HealAll": "Heal All",
     "HealAllConfirm": "Set everyone to full HP?",
     "RequestRoll": "Request Roll",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -952,8 +952,14 @@ Hooks.on("combatStart", () => PF2ETokenBar.render());
 Hooks.on("combatEnd", async () => {
   PF2ETokenBar.render();
   if (game.user.isGM && game.settings.get("pf2e-token-bar", "quickLoot")) {
-    await PF2ETokenBar.transferDefeatedLoot();
-    PF2ETokenBar.openLootActor("Loot");
+    await Dialog.confirm({
+      title: game.i18n.localize("PF2ETokenBar.QuickLootConfirmTitle"),
+      content: `<p>${game.i18n.localize("PF2ETokenBar.QuickLootConfirmContent")}</p>`,
+      yes: async () => {
+        await PF2ETokenBar.transferDefeatedLoot();
+        PF2ETokenBar.openLootActor("Loot");
+      }
+    });
   }
 });
 Hooks.on("combatTurn", () => {


### PR DESCRIPTION
## Summary
- prompt GMs for confirmation before auto-looting after combat
- localize quick loot confirmation text in English and German

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a610cb95e08327b8cc4c5f16cf7486