### PR TITLE
Restrict item drops to physical item types

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -63,6 +63,7 @@
     "Unlock": "Unlock",
     "HeroPoints": "Hero Points",
     "TokenMissing": "Token '{name}' not found",
+    "InvalidItemType": "Only physical items can be dropped here",
     "PartySheetMissing": "Party Sheet not found",
     "EncounterDifficulty": "Encounter Difficulty",
     "Difficulties": {

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -718,6 +718,12 @@ class PF2ETokenBar {
       const item = await fromUuid(parsed.uuid);
       if (!(item instanceof Item)) throw new Error("Item not found");
 
+      const allowedTypes = CONFIG.PF2E?.physicalItemTypes ?? ["weapon", "armor", "shield", "equipment", "consumable", "treasure", "backpack"];
+      if (!allowedTypes.includes(item.type)) {
+        ui.notifications.warn(game.i18n.localize("PF2ETokenBar.InvalidItemType"));
+        return;
+      }
+
       const sourceActor = item.actor;
 
       const actor = target && typeof target === "object"


### PR DESCRIPTION
## Summary
- validate item type when dropping and allow only Quick Loot's physical types
- notify users for disallowed item types
- add localization string for invalid drop message

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61e4884ac8327875d76bc41f1c8d5