### PR TITLE
Add optional Fortification rune automation

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -20,6 +20,10 @@
       "QuickLoot": {
         "Name": "Schnellbeute",
         "Hint": "Überträgt nach dem Kampf automatisch die Beute besiegter NSC und öffnet den Beute-Akteur."
+      },
+      "AutoFortification": {
+        "Name": "Fortification-Automatisierung",
+        "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"
       }
     },
     "QuickLootConfirmTitle": "Schnellbeute",

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,6 +20,10 @@
       "QuickLoot": {
         "Name": "Quick Loot",
         "Hint": "Automatically transfer defeated NPC loot and open the Loot actor on combat end."
+      },
+      "AutoFortification": {
+        "Name": "Auto Fortification",
+        "Hint": "Automatically prompt a Fortification flat check on critical hits"
       }
     },
     "QuickLootConfirmTitle": "Quick Loot",

--- a/module.json
+++ b/module.json
@@ -18,7 +18,8 @@
     }
   ],
   "esmodules": [
-    "scripts/token-bar.js"
+    "scripts/token-bar.js",
+    "scripts/rune-automation.js"
   ],
   "styles": [
     "styles/token-bar.css"

--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -1,0 +1,67 @@
+Hooks.once("init", () => {
+  game.settings.register("pf2e-token-bar", "autoFortification", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.AutoFortification.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.AutoFortification.Hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+});
+
+Hooks.on("createChatMessage", async (message) => {
+  if (!game.settings.get("pf2e-token-bar", "autoFortification")) return;
+
+  const context = message.flags.pf2e?.context;
+  if (context?.type !== "damage-roll" || context?.outcome !== "criticalSuccess") return;
+
+  const targetUuid = context.target?.actor;
+  const target = targetUuid ? await fromUuid(targetUuid) : null;
+  if (!(target instanceof ActorPF2e)) return;
+
+  const options = target.rollOptions.all;
+  const hasFort = options["armor:rune:property:fortification"];
+  const hasGreater = options["armor:rune:property:greater-fortification"];
+  if (!hasFort && !hasGreater) return;
+
+  const dc = hasGreater ? 14 : 17;
+
+  const content = `
+    <div class="fortification-check" data-message-id="${message.id}">
+      <button class="fort-btn" data-dc="${dc}">
+        Fortification Flat Check (DC ${dc})
+      </button>
+    </div>`;
+
+  await ChatMessage.create({
+    speaker: ChatMessage.getSpeaker({ actor: target }),
+    flavor: `Fortification – ${target.name}`,
+    content,
+  });
+});
+
+Hooks.on("renderChatMessage", (message, html) => {
+  if (!game.settings.get("pf2e-token-bar", "autoFortification")) return;
+
+  html.find("button.fort-btn").on("click", async (event) => {
+    const button = event.currentTarget;
+    if (button.disabled) return;
+    button.disabled = true;
+
+    const dc = Number(button.dataset.dc);
+    const msgId = button.closest(".fortification-check").dataset.messageId;
+    const original = game.messages.get(msgId);
+
+    const roll = await new Roll("1d20").evaluate({ async: true });
+    await roll.toMessage({ flavor: `Fortification (DC ${dc})` });
+
+    if (roll.total >= dc) {
+      await original.update({
+        "flags.pf2e.context.outcome": "success",
+        "flags.pf2e.damageRoll.outcome": "success",
+      });
+      ui.notifications.info("Critical downgraded to normal damage.");
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- add setting to enable automated Fortification rune checks
- localize AutoFortification option in English and German
- include new rune-automation module script

## Testing
- `node --check scripts/rune-automation.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a63674e6dc832781968503d2704d6b