### PR TITLE
Use isOfType for rune fortification target check

### DIFF
--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -17,7 +17,7 @@ Hooks.on("createChatMessage", async (message) => {
 
   const targetUuid = context.target?.actor;
   const target = targetUuid ? await fromUuid(targetUuid) : null;
-  if (!(target instanceof ActorPF2e)) return;
+  if (!target?.isOfType?.("creature")) return;
 
   const options = target.rollOptions.all;
   const hasFort = options["armor:rune:property:fortification"];


### PR DESCRIPTION
## Summary
- avoid ReferenceError by using `isOfType('creature')` instead of `ActorPF2e`

## Testing
- `node - <<'NODE'
const hooks={};
Hooks={once:(e,f)=>f(),on:(e,f)=>hooks[e]=f};
global.game={settings:{get:()=>true,register:()=>{}},i18n:{localize:s=>s},messages:{get:id=>null}};
ChatMessage={getSpeaker:({actor})=>({alias:actor.name}),create:async d=>console.log('ChatMessage.create',d.flavor)};
fromUuid=async()=>({isOfType:()=>true,rollOptions:{all:{'armor:rune:property:fortification':true}},name:'Dummy'});
Roll=class{constructor(){this.total=20}async evaluate(){return this}async toMessage(o){console.log('Roll.toMessage',o.flavor)}};
ui={notifications:{info:console.log}};
require('./scripts/rune-automation.js');
hooks['createChatMessage']({flags:{pf2e:{context:{type:'damage-roll',outcome:'criticalSuccess',target:{actor:'uuid'}}}},id:'origMsgId'}).then(()=>console.log('Hook executed'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a63c8d36388327aaec92f623f9f42d