### PR TITLE
Add success evaluation for fortification rolls

### DIFF
--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -53,14 +53,19 @@ Hooks.on("renderChatMessage", (message, html) => {
     const original = game.messages.get(msgId);
 
     const roll = await new Roll("1d20").evaluate({ async: true });
-    await roll.toMessage({ flavor: `Fortification (DC ${dc})` });
+    const success = roll.total >= dc;
+    await roll.toMessage({
+      flavor: `Fortification (DC ${dc}) – ${success ? game.i18n.localize("PF2E.Check.Success") : game.i18n.localize("PF2E.Check.Failure")}`,
+    });
 
-    if (roll.total >= dc) {
+    if (success) {
       await original.update({
         "flags.pf2e.context.outcome": "success",
         "flags.pf2e.damageRoll.outcome": "success",
       });
       ui.notifications.info("Critical downgraded to normal damage.");
+    } else {
+      ui.notifications.warn("Fortification failed.");
     }
   });
 });


### PR DESCRIPTION
## Summary
- add success check to fortification roll handler
- include localized success or failure text in roll chat messages
- warn players when fortification fails to downgrade a critical

## Testing
- `node --check scripts/rune-automation.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6450a01b88327a937e7dbdb814b19