### PR TITLE
Use PF2E CheckRoll for fortification flat checks

### DIFF
--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -53,10 +53,14 @@ Hooks.on("renderChatMessage", (message, html) => {
     const original = game.messages.get(msgId);
     const item = original?.item;
 
-    const roll = await new Roll("1d20").evaluate({ async: true });
-    await roll.toMessage({ flavor: `Fortification (DC ${dc})` });
+    const roll = await new game.pf2e.CheckRoll(
+      "1d20",
+      {},
+      { type: "flat-check", dc: { value: dc, label: "PF2E.Check.Result.Flat" } }
+    ).evaluate({ async: true });
+    await roll.toMessage({ speaker: message.speaker, flavor: `Fortification (DC ${dc})` });
 
-    if (roll.total >= dc) {
+    if (roll.degreeOfSuccess >= 2) {
       await original.update({ "flags.pf2e.context.outcome": "success" });
       ui.notifications.info("Critical downgraded to normal damage.");
     }


### PR DESCRIPTION
## Summary
- switch fortification flat check to `game.pf2e.CheckRoll`
- downgrade critical hits based on the check roll result

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b4c62c888327b2981bc5e5df8ddf