### PR TITLE
Use registered CheckRoll for fortification flat checks

### DIFF
--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -53,7 +53,8 @@ Hooks.on("renderChatMessage", (message, html) => {
     const original = game.messages.get(msgId);
     const item = original?.item;
 
-    const roll = await new game.pf2e.CheckRoll(
+    const CheckRoll = CONFIG.Dice.rolls.find((r) => r.name === "CheckRoll");
+    const roll = await new CheckRoll(
       "1d20",
       {},
       { type: "flat-check", dc: { value: dc, label: "PF2E.Check.Result.Flat" } }


### PR DESCRIPTION
## Summary
- Obtain `CheckRoll` from registered roll classes and use it for fortification flat checks

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Kazguls-PF2e-Token-Bar/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c075c6ac8327a626a85ef0a3f4f9