### PR TITLE
Add stack controls and tooltip chat for effects

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -189,6 +189,12 @@
   pointer-events: none;
 }
 
+.pf2e-effect-chat {
+  float: right;
+  cursor: pointer;
+  margin-left: 4px;
+}
+
 .pf2e-token-bar-tooltip {
   max-width: 300px;
 }


### PR DESCRIPTION
## Summary
- Allow left-click to increase and right-click to decrease stackable effects
- Always show stack counts and add chat icon in effect tooltips

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check scripts/token-bar.js`

------
https://chatgpt.com/codex/tasks/task_e_68a707c7bd488327b9df89dce4893de3