### PR TITLE
Add effect name to token bar tooltips

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -368,7 +368,8 @@ class PF2ETokenBar {
               documents: true,
               rollData: doc.actor?.getRollData?.(),
             });
-            return `${enriched}<i class="fas fa-comment pf2e-effect-chat"></i>`;
+            const name = doc.name ?? effect.name;
+            return `<strong>${name}</strong>${enriched}<i class="fas fa-comment pf2e-effect-chat"></i>`;
           },
           cssClass: "pf2e-token-bar-tooltip",
         });


### PR DESCRIPTION
## Summary
- Include the effect name alongside enriched description in token-bar tooltips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ba8f7ac8327879123aaf997162a