### PR TITLE
Use original effect description for tooltips

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -362,7 +362,7 @@ class PF2ETokenBar {
           content: async () => {
             const doc = await fromUuid(uuid);
             if (!doc) return "";
-            const description = doc.system?.description?.value ?? "";
+            const description = doc._source?.system?.description?.value ?? doc.system?.description?.value ?? "";
             const enriched = await TextEditor.enrichHTML(description, {
               async: true,
               documents: true,
@@ -382,7 +382,7 @@ class PF2ETokenBar {
               ev.stopPropagation();
               try {
                 const doc = await fromUuid(uuid);
-                const description = doc.system?.description?.value ?? "";
+                const description = doc._source?.system?.description?.value ?? doc.system?.description?.value ?? "";
                 const content = await TextEditor.enrichHTML(description, {
                   async: true,
                   documents: true,


### PR DESCRIPTION
## Summary
- use `_source` description for effect tooltips and chat messages to preserve original HTML

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72e2401b08327bfbdc53d474f7229