### PR TITLE
Always show token HP bars

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -239,7 +239,8 @@ class PF2ETokenBar {
 
       const isCharacter = actor.isOfType?.("character") ?? actor.type === "character";
       const isNPC = actor.isOfType?.("npc") ?? actor.type === "npc";
-      const showHp = game.user.isGM || !isNPC;
+      const showHpBar = true;
+      const showHpNumeric = game.user.isGM || !isNPC;
       if (isCharacter) {
         const tabContainer = document.createElement("div");
         tabContainer.classList.add("pf2e-token-tabs");
@@ -285,16 +286,18 @@ class PF2ETokenBar {
         tabContainer.appendChild(proficiencyTab);
       }
 
-      if (showHp) {
-        const hp = actor.system?.attributes?.hp ?? {};
-        const hpValue = Number(hp.value) || 0;
-        const hpMax = Number(hp.max) || 0;
+      const hp = actor.system?.attributes?.hp ?? {};
+      const hpValue = Number(hp.value) || 0;
+      const hpMax = Number(hp.max) || 0;
 
+      if (showHpNumeric) {
         const hpText = document.createElement("div");
         hpText.classList.add("pf2e-hp-text");
         hpText.innerText = `${hpValue}`;
         wrapper.appendChild(hpText);
+      }
 
+      if (showHpBar) {
         const barOuter = document.createElement("div");
         barOuter.classList.add("pf2e-hp-bar");
         const barInner = document.createElement("div");


### PR DESCRIPTION
## Summary
- Always append an HP bar to tokens
- Only display numeric HP when the user is a GM or viewing a non-NPC

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*
- ✅ `node - <<'NODE'
function showHpFlags(gameIsGM, isNPC){
  const showHpBar = true;
  const showHpNumeric = gameIsGM || !isNPC;
  return { showHpBar, showHpNumeric};
}
console.log('player vs NPC', showHpFlags(false, true));
console.log('player vs PC', showHpFlags(false, false));
console.log('GM vs NPC', showHpFlags(true, true));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a731e376108327bbae4fdf597c4f46