### PR TITLE
feat: speak effect description

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -403,6 +403,25 @@ class PF2ETokenBar {
           }, 50);
         });
 
+        img.addEventListener("mouseenter", async () => {
+          try {
+            const doc = await fromUuid(uuid);
+            const description = doc?._source?.system?.description?.value ?? doc?.system?.description?.value ?? "";
+            const enriched = await TextEditor.enrichHTML(description, {
+              async: true,
+              documents: true,
+              rollData: doc?.actor?.getRollData?.(),
+            });
+            canvas.hud.bubbles?.say?.(token, enriched);
+          } catch (err) {
+            console.error("PF2ETokenBar | failed to show effect bubble", err);
+          }
+        });
+
+        img.addEventListener("mouseleave", () => {
+          canvas.hud.bubbles?.clear?.(token);
+        });
+
         img.addEventListener("click", async event => {
           event.preventDefault();
           if (canStack) {


### PR DESCRIPTION
## Summary
- show effect descriptions as token speech bubbles when hovering an effect
- clear bubble on mouse leave

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75a5a78188327b8eba764633e7ab3