### PR TITLE
Use grid layout for effect icons

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -166,9 +166,12 @@
 }
 
 .pf2e-effect-bar {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(4, 24px);
+  grid-auto-rows: 24px;
   gap: 3px;
   margin-top: 2px;
+  justify-content: center;
 }
 
 .pf2e-effect {


### PR DESCRIPTION
## Summary
- Arrange effect icons in a 4xN grid with fixed 24px cells and centered alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a782f4cd0883279f035123a3f79414