### PR TITLE
Refactor combat turn scrolling

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -711,6 +711,15 @@ class PF2ETokenBar {
     });
 
     document.body.appendChild(bar);
+    this.scrollActiveToken();
+  }
+
+  static scrollActiveToken() {
+    requestAnimationFrame(() =>
+      document
+        .querySelector("#pf2e-token-bar .active-turn")
+        ?.scrollIntoView({ behavior: "smooth", inline: "center" })
+    );
   }
 
     static _partyTokens() {
@@ -1112,12 +1121,7 @@ Hooks.on("combatStart", () => PF2ETokenBar.render());
 Hooks.on("combatEnd", async () => {
   PF2ETokenBar.render();
 });
-Hooks.on("combatTurn", () => {
-  PF2ETokenBar.render();
-  document
-    .querySelector("#pf2e-token-bar .active-turn")
-    ?.scrollIntoView({ behavior: "smooth", inline: "center" });
-});
+Hooks.on("combatTurn", () => PF2ETokenBar.scrollActiveToken());
 Hooks.on("updateCombatant", () => PF2ETokenBar.render());
 Hooks.on("renderChatMessage", (_message, html) => {
   const links = html[0]?.querySelectorAll("a.pf2e-token-bar-roll") ?? [];


### PR DESCRIPTION
## Summary
- avoid redundant renders during combat turns
- smooth scroll to active combatant after rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8104546fc8327a4c25ff12c9824fb