### PR TITLE
Hide encounter difficulty from players

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -144,7 +144,7 @@ class PF2ETokenBar {
 
 
     const threat = activeCombat?.metrics?.threat ?? activeCombat?.analyze()?.threat;
-    if (threat) {
+    if (game.user.isGM && threat) {
       const difficultyDisplay = document.createElement("div");
       const capThreat = threat.charAt(0).toUpperCase() + threat.slice(1);
       difficultyDisplay.classList.add("pf2e-encounter-difficulty", `pf2e-encounter-${threat}`);


### PR DESCRIPTION
## Summary
- show encounter difficulty only to GMs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8114384f083278ba63769473c24d2