### PR TITLE
feat: add instant scroll option

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -722,15 +722,19 @@ class PF2ETokenBar {
     });
 
     document.body.appendChild(bar);
-    this.scrollActiveToken();
+    this.scrollActiveToken("instant");
   }
 
-  static scrollActiveToken() {
-    requestAnimationFrame(() =>
-      document
-        .querySelector("#pf2e-token-bar .active-turn")
-        ?.scrollIntoView({ behavior: "smooth", inline: "center" })
-    );
+  static scrollActiveToken(behavior = "smooth") {
+    const active = document.querySelector("#pf2e-token-bar .active-turn");
+    if (!active) return;
+    if (behavior === "smooth") {
+      requestAnimationFrame(() =>
+        active.scrollIntoView({ behavior, inline: "center" })
+      );
+    } else {
+      active.scrollIntoView({ behavior, inline: "center" });
+    }
   }
 
     static _partyTokens() {


### PR DESCRIPTION
## Summary
- add optional behavior to `scrollActiveToken` for instant scroll support
- center active token instantly when bar renders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82638301883279591472ee4401414