### PR TITLE
Support dropping effects onto actors

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -71,6 +71,7 @@
     "Unlock": "Entsperren",
     "HeroPoints": "Heldenpunkte",
     "TokenMissing": "Token '{name}' nicht gefunden",
+    "InvalidItemType": "Hier können nur physische Gegenstände oder Effekte abgelegt werden",
     "PartySheetMissing": "Gruppenblatt nicht gefunden",
     "EncounterDifficulty": "Begegnungsschwierigkeit",
     "Difficulties": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -71,7 +71,7 @@
     "Unlock": "Unlock",
     "HeroPoints": "Hero Points",
     "TokenMissing": "Token '{name}' not found",
-    "InvalidItemType": "Only physical items can be dropped here",
+    "InvalidItemType": "Only physical items or effects can be dropped here",
     "PartySheetMissing": "Party Sheet not found",
     "EncounterDifficulty": "Encounter Difficulty",
     "Difficulties": {

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -883,10 +883,19 @@ class PF2ETokenBar {
       const item = await fromUuid(parsed.uuid);
       if (!(item instanceof Item)) throw new Error("Item not found");
 
-      const allowedTypes = CONFIG.PF2E?.physicalItemTypes ?? ["weapon", "armor", "shield", "equipment", "consumable", "treasure", "backpack"];
-      if (!allowedTypes.includes(item.type)) {
-        ui.notifications.warn(game.i18n.localize("PF2ETokenBar.InvalidItemType"));
-        return;
+      const isEffect = item.isOfType("effect", "condition");
+
+      if (isEffect) {
+        if (typeof target !== "object") {
+          ui.notifications.warn(game.i18n.localize("PF2ETokenBar.InvalidItemType"));
+          return;
+        }
+      } else {
+        const allowedTypes = CONFIG.PF2E?.physicalItemTypes ?? ["weapon", "armor", "shield", "equipment", "consumable", "treasure", "backpack"];
+        if (!allowedTypes.includes(item.type)) {
+          ui.notifications.warn(game.i18n.localize("PF2ETokenBar.InvalidItemType"));
+          return;
+        }
       }
 
       const sourceActor = item.actor;
@@ -903,7 +912,7 @@ class PF2ETokenBar {
 
       await actor.createEmbeddedDocuments("Item", [item.toObject()]);
 
-      if (sourceActor && sourceActor !== actor) await item.delete();
+      if (!isEffect && sourceActor && sourceActor !== actor) await item.delete();
     } catch (err) {
       console.error(err);
       ui.notifications.error(err.message || "Failed to drop item.");


### PR DESCRIPTION
## Summary
- allow effect/condition item drops on actors without deleting the source item
- clarify invalid item type warning and add German translation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a85a7817a88327bf1312009e5d1c53