### PR TITLE
Add sticky header to token bar

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -136,6 +136,10 @@ class PF2ETokenBar {
       bar.style.right = "0px";
     }
 
+    const header = document.createElement("div");
+    header.classList.add("pf2e-token-bar-header");
+    bar.appendChild(header);
+
     const tokenContainer = document.createElement("div");
     tokenContainer.classList.add("pf2e-token-bar-content");
     if (orientation === "vertical") {
@@ -159,14 +163,14 @@ class PF2ETokenBar {
         const capThreat = threat.charAt(0).toUpperCase() + threat.slice(1);
         difficultyDisplay.classList.add("pf2e-encounter-difficulty", `pf2e-encounter-${threat}`);
         difficultyDisplay.innerText = game.i18n.localize(`PF2ETokenBar.Difficulties.${capThreat}`);
-        tokenContainer.prepend(difficultyDisplay);
+        header.appendChild(difficultyDisplay);
       }
 
       if (activeCombat?.round > 0) {
         const roundDisplay = document.createElement("div");
         roundDisplay.classList.add("pf2e-round-display");
         roundDisplay.innerText = game.i18n.format("PF2ETokenBar.Round", { round: activeCombat.round });
-        tokenContainer.prepend(roundDisplay);
+        header.prepend(roundDisplay);
       }
     }
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -42,6 +42,15 @@
   padding-top: 8px;
 }
 
+#pf2e-token-bar .pf2e-token-bar-header {
+  display: flex;
+  gap: 4px;
+  position: sticky;
+  top: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1;
+}
+
 #pf2e-token-bar .pf2e-token-bar-controls {
   display: grid;
   grid-template-columns: repeat(3, auto);


### PR DESCRIPTION
## Summary
- Add dedicated header element for round and encounter difficulty displays
- Style token bar header to remain visible while token list scrolls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8628192bc83278a5d4508eba0dd1a