### PR TITLE
feat: show effect descriptions on ctrl-click

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -445,6 +445,33 @@ class PF2ETokenBar {
 
         img.addEventListener("click", async event => {
           event.preventDefault();
+          if (event.ctrlKey) {
+            event.stopPropagation();
+            try {
+              const doc = await fromUuid(uuid);
+              const description = doc?._source?.system?.description?.value ?? doc?.system?.description?.value ?? "";
+              const enriched = await TextEditor.enrichHTML(description, {
+                async: true,
+                documents: true,
+                rollData: doc?.actor?.getRollData?.()
+              });
+              const dialog = new Dialog({
+                title: doc?.name ?? "",
+                content: enriched,
+                buttons: {
+                  chat: {
+                    label: '<i class="fas fa-comment"></i>',
+                    callback: () => ChatMessage.create({ content: enriched })
+                  }
+                }
+              });
+              dialog.render(true);
+              dialog.element.find('button').addClass('pf2e-effect-dialog-chat');
+            } catch (err) {
+              console.error("PF2ETokenBar | failed to show effect description", err);
+            }
+            return;
+          }
           if (canStack) {
             try {
               if (typeof effect.increase === "function") {

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -207,6 +207,11 @@
   margin-left: 4px;
 }
 
+.pf2e-effect-dialog-chat {
+  cursor: pointer;
+  font-size: 1.2em;
+}
+
 .pf2e-token-bar-tooltip {
   max-width: 300px;
 }


### PR DESCRIPTION
## Summary
- Control-click effect icons to view enriched description in a dialog
- Send effect descriptions to chat via new dialog button
- Add styling for chat button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a864b26eb4832781563a53e7f0cf82