### PR TITLE
feat: add encounter scrollbar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Under **Settings → Module Settings → PF2e Token-Bar**:
 - **Lock bar** – prevents accidental moving.
 - **Position** – automatically saved after moving.
 - **Encounter mode** – when enabled (default), the bar switches to combatants during encounters and shows round counter and difficulty.
+- **Encounter scrollbar** – when disabled, the bar extends to the right without scrolling.
 - **Quick loot** – automatically transfer defeated NPC loot and open the Loot actor when combat ends.
 
 ---

--- a/lang/de.json
+++ b/lang/de.json
@@ -25,6 +25,10 @@
         "Name": "Encounter-Modus aktivieren",
         "Hint": "Verwendet Encounter-spezifische Funktionen wie Kampftoken, Rundenzähler und Schwierigkeitsanzeige"
       },
+      "EncounterScroll": {
+        "Name": "Begegnungs-Scrollbalken",
+        "Hint": "Wenn deaktiviert, erweitert sich die Leiste nach rechts ohne Scrollen"
+      },
       "AutoFortification": {
         "Name": "Fortification-Automatisierung",
         "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"

--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,10 @@
         "Name": "Enable Encounter Mode",
         "Hint": "Use encounter features such as combatant tokens, round counter, and difficulty display"
       },
+      "EncounterScroll": {
+        "Name": "Encounter scrollbar",
+        "Hint": "When disabled, the bar extends to the right without scrolling"
+      },
       "AutoFortification": {
         "Name": "Auto Fortification",
         "Hint": "Automatically prompt a Fortification flat check on critical hits"

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -81,6 +81,15 @@ Hooks.once("init", () => {
     default: true,
     onChange: () => PF2ETokenBar.render(),
   });
+  game.settings.register("pf2e-token-bar", "encounterScroll", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.EncounterScroll.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.EncounterScroll.Hint"),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: () => PF2ETokenBar.render(),
+  });
 });
 
 class PF2ETokenBar {
@@ -147,12 +156,18 @@ class PF2ETokenBar {
       tokenContainer.style.overflowX = "hidden";
       tokenContainer.style.maxHeight = "80vh";
     } else {
-      tokenContainer.style.overflowX = "auto";
       tokenContainer.style.overflowY = "hidden";
       const tokenWidth = 64;
       const gap = 12;
       const maxWidth = (tokenWidth + gap) * 8;
-      tokenContainer.style.setProperty("--token-bar-max-width", `${maxWidth}px`);
+      const encounterScroll = game.settings.get("pf2e-token-bar", "encounterScroll");
+      if (encounterMode && !encounterScroll) {
+        tokenContainer.style.overflowX = "visible";
+        tokenContainer.style.setProperty("--token-bar-max-width", "none");
+      } else {
+        tokenContainer.style.overflowX = "auto";
+        tokenContainer.style.setProperty("--token-bar-max-width", `${maxWidth}px`);
+      }
     }
     bar.appendChild(tokenContainer);
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -31,6 +31,7 @@
   overflow-x: auto;
   overflow-y: visible;
   max-width: var(--token-bar-max-width, 80vw);
+  /* set --token-bar-max-width: none to remove the max-width */
   padding-top: 8px;
 }
 


### PR DESCRIPTION
## Summary
- add encounterScroll setting to toggle scrollbar in encounters
- adjust render logic to allow full-width bar when scrolling disabled
- document setting and add translations

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check scripts/token-bar.js`


------
https://chatgpt.com/codex/tasks/task_e_68a89b41ef088327a3a1e9315784fd04