### PR TITLE
feat: show AC overlay on tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ Active when an **encounter is running** or combatants exist.
 
 - Shows all combatants, sorted by initiative (NPCs first on tie).  
 - **Initiative values** per token; missing values show “RFC!” (roll for initiative).  
-- **Current turn:** the active combatant’s token is highlighted.  
-- **Round counter** and **encounter difficulty** (Trivial to Extreme).  
+- **Current turn:** the active combatant’s token is highlighted.
+- **Round counter** and **encounter difficulty** (Trivial to Extreme).
 - **Delay/play icons:** delay a turn or resume it, including hourglass/play symbols.
+- **Armor Class indicator:** shield icon with AC value on character tokens.
 
 ### Additional Buttons
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -74,6 +74,7 @@
     "Lock": "Sperren",
     "Unlock": "Entsperren",
     "HeroPoints": "Heldenpunkte",
+    "ArmorClass": "Rüstungsklasse",
     "TokenMissing": "Token '{name}' nicht gefunden",
     "InvalidItemType": "Hier können nur physische Gegenstände oder Effekte abgelegt werden",
     "PartySheetMissing": "Gruppenblatt nicht gefunden",

--- a/lang/en.json
+++ b/lang/en.json
@@ -74,6 +74,7 @@
     "Lock": "Lock",
     "Unlock": "Unlock",
     "HeroPoints": "Hero Points",
+    "ArmorClass": "Armor Class",
     "TokenMissing": "Token '{name}' not found",
     "InvalidItemType": "Only physical items or effects can be dropped here",
     "PartySheetMissing": "Party Sheet not found",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -269,6 +269,16 @@ class PF2ETokenBar {
 
       const isCharacter = actor.isOfType?.("character") ?? actor.type === "character";
       const isNPC = actor.isOfType?.("npc") ?? actor.type === "npc";
+      if (encounterMode && isCharacter) {
+        const ac = actor.system?.attributes?.ac?.value ?? 0;
+        const acIcon = document.createElement("div");
+        acIcon.classList.add("pf2e-ac-icon");
+        acIcon.innerHTML = `<i class="fas fa-shield-alt"></i> ${ac}`;
+        const acTitle = game.i18n.localize("PF2ETokenBar.ArmorClass");
+        acIcon.title = acTitle;
+        acIcon.setAttribute("aria-label", acTitle);
+        wrapper.appendChild(acIcon);
+      }
       const showHpBar = true;
       const showHpNumeric = game.user.isGM || !isNPC;
       if (isCharacter) {

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -136,6 +136,20 @@
   flex-shrink: 0;
 }
 
+.pf2e-ac-icon {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 3px;
+  font-size: 12px;
+  padding: 0 2px;
+  z-index: 1;
+}
+
 #pf2e-token-bar .pf2e-token-wrapper.pf2e-drop-hover {
   filter: brightness(1.2);
 }


### PR DESCRIPTION
## Summary
- show character AC in encounter mode tokens with shield icon
- style and localize Armor Class indicator
- document AC indicator in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac513a7c7083278678723b1eac2740