### PR TITLE
Add short rest button for party sheet access

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -44,6 +44,7 @@
     "AddPartyToEncounter": "Gruppe in Begegnung übernehmen",
     "StartEncounter": "Begegnung starten",
     "EndEncounter": "Begegnung beenden",
+    "ShortRest": "Kurze Rast",
     "NPCInit": "NSC-Ini",
     "Prev": "Zurück",
     "Next": "Weiter",

--- a/lang/en.json
+++ b/lang/en.json
@@ -44,6 +44,7 @@
     "AddPartyToEncounter": "Add Party to Encounter",
     "StartEncounter": "Start Encounter",
     "EndEncounter": "End Encounter",
+    "ShortRest": "Short Rest",
     "NPCInit": "NPC Init",
     "Prev": "Prev",
     "Next": "Next",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -658,6 +658,14 @@ class PF2ETokenBar {
             controls.appendChild(encounterBtn);
         }
 
+        const shortRestBtn = document.createElement("button");
+        shortRestBtn.innerHTML = '<i class="fas fa-campground"></i>';
+        shortRestBtn.title = game.i18n.localize("PF2ETokenBar.ShortRest");
+        shortRestBtn.addEventListener("click", () =>
+          game.actors.party?.sheet.render(true, { tab: "exploration" })
+        );
+        controls.appendChild(shortRestBtn);
+
         const lootGroup = document.createElement("div");
         lootGroup.classList.add("pf2e-loot-controls");
         controls.appendChild(lootGroup);


### PR DESCRIPTION
## Summary
- add localized "Short Rest" strings in English and German
- provide a new token bar control to open the party sheet on the Exploration tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac619140b8832793d509f6d7f5a28c