### PR TITLE
feat: place AC icon below targeting indicator

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -138,7 +138,7 @@
 
 .pf2e-ac-icon {
   position: absolute;
-  bottom: 2px;
+  top: 16px;
   right: 2px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- position the AC icon beneath the targeting indicator for cleaner alignment

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acd350c25483279b6c6eb0e78aba19