### PR TITLE
Reduce hero point size

### DIFF
--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -173,13 +173,13 @@
 #pf2e-token-bar .pf2e-hero-points {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 1px;
   margin-top: 2px;
 }
 
 #pf2e-token-bar .pf2e-hero-point {
-  width: 16px;
-  height: 16px;
+  width: 8px;
+  height: 8px;
   border: 1px solid gold;
   border-radius: 50%;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Shrink hero point markers to 8px
- Tighten spacing between hero points

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad99cfddf48327804ddc4243fa38b7