### PR TITLE
Hide hidden combatants from players

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ Active when an **encounter is running** or combatants exist.
 
 ### Display
 
-- Shows all combatants, sorted by initiative (NPCs first on tie).  
-- **Initiative values** per token; missing values show “RFC!” (roll for initiative).  
+- Shows all combatants, sorted by initiative (NPCs first on tie).
+- Hidden combatants are only shown to GMs.
+- **Initiative values** per token; missing values show “RFC!” (roll for initiative).
 - **Current turn:** the active combatant’s token is highlighted.
 - **Round counter** and **encounter difficulty** (Trivial to Extreme).
 - **Delay/play icons:** delay a turn or resume it, including hourglass/play symbols.

--- a/lang/de.json
+++ b/lang/de.json
@@ -23,7 +23,7 @@
       },
       "EncounterMode": {
         "Name": "Encounter-Modus aktivieren",
-        "Hint": "Verwendet Encounter-spezifische Funktionen wie Kampftoken, Rundenzähler und Schwierigkeitsanzeige"
+        "Hint": "Verwendet Encounter-spezifische Funktionen wie Kampftoken, Rundenzähler und Schwierigkeitsanzeige. Verborgene NSC werden nur SL angezeigt."
       },
       "EncounterScroll": {
         "Name": "Begegnungs-Scrollbalken",

--- a/lang/en.json
+++ b/lang/en.json
@@ -23,7 +23,7 @@
       },
       "EncounterMode": {
         "Name": "Enable Encounter Mode",
-        "Hint": "Use encounter features such as combatant tokens, round counter, and difficulty display"
+        "Hint": "Use encounter features such as combatant tokens, round counter, and difficulty display. Hidden combatants are only shown to GMs."
       },
       "EncounterScroll": {
         "Name": "Encounter scrollbar",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -799,7 +799,8 @@ class PF2ETokenBar {
         const bIsPlayer = b.actor?.hasPlayerOwner ? 1 : 0;
         return aIsPlayer - bIsPlayer;   // NPCs (0) vor PCs (1)
       });
-      const tokens = combatants.map(c => canvas.tokens.get(c.tokenId)).filter(t => t);
+      let tokens = combatants.map(c => canvas.tokens.get(c.tokenId)).filter(t => t);
+      tokens = tokens.filter(t => !t.document.hidden || game.user.isGM);
       this.debug(
         `PF2ETokenBar | _combatTokens found ${tokens.length} tokens`,
         tokens.map(t => t.id)


### PR DESCRIPTION
## Summary
- filter combat tokens to hide hidden combatants from non-GM users
- document that only GMs see hidden combatants

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5577b834c8327be7801065ff85629