### PR TITLE
feat: allow additive targeting with shift

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -1122,7 +1122,10 @@ Hooks.once("ready", () => {
 
     if (event.code === "KeyT" && PF2ETokenBar.hoveredToken) {
       const token = PF2ETokenBar.hoveredToken;
-      token.setTarget(!token.isTargeted, { user: game.user });
+      token.setTarget(!token.isTargeted, {
+        user: game.user,
+        releaseOthers: !event.shiftKey
+      });
     }
   };
   document.addEventListener("keydown", keydownListener);


### PR DESCRIPTION
## Summary
- ensure Shift+T adds or removes targets without clearing existing ones

## Testing
- `npm test` *(fails: Could not read package.json)*
- simulated keydown events in Node to verify `releaseOthers` respects Shift state

------
https://chatgpt.com/codex/tasks/task_e_68b68e9a7fe88327ae86437b0d4c830c