### PR TITLE
Add setting to toggle remastered sheet styles

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,8 @@
   ],
   "esmodules": [
     "scripts/token-bar.js",
-    "scripts/rune-automation.js"
+    "scripts/rune-automation.js",
+    "scripts/remaster-sheets.js"
   ],
   "styles": [
     "styles/token-bar.css"

--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -1,0 +1,24 @@
+Hooks.once("init", () => {
+  game.settings.register("pf2e-token-bar", "characterSheetStyle", {
+    name: "Character Sheet Style",
+    scope: "client",
+    config: true,
+    type: String,
+    choices: {
+      standard: "standard",
+      remaster: "remaster",
+      red: "red",
+      dark: "dark"
+    },
+    default: "standard"
+  });
+});
+
+Hooks.on("renderActorSheet", (_app, html) => {
+  const style = game.settings.get("pf2e-token-bar", "characterSheetStyle");
+  const element = html[0];
+  if (!element) return;
+  element.classList.remove("dark-theme", "remaster", "red", "dark");
+  if (style !== "standard") element.classList.add("dark-theme", style);
+});
+


### PR DESCRIPTION
## Summary
- add `characterSheetStyle` client setting with multiple color theme options
- apply selected theme when rendering actor sheets
- load the new script through the module manifest

## Testing
- `node --check scripts/remaster-sheets.js`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ed7f1b708327ac45d502b6b86765