### PR TITLE
feat: add remaster sheet mode setting

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -36,6 +36,16 @@
       "AutoFortification": {
         "Name": "Fortification-Automatisierung",
         "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"
+      },
+      "RemasterSheetMode": {
+        "Name": "Remaster-Sheets",
+        "Hint": "Aktiviert alternative Farbgebungen für Charakter- und NSC-Sheets",
+        "Choices": {
+          "Off": "Aus",
+          "RemasterLight": "Original (Remaster)",
+          "RemasterDark": "Dark Mode (Remaster)",
+          "RemasterRed": "Dark Mode (Rot)"
+        }
       }
     },
     "QuickLootConfirmTitle": "Schnellbeute",

--- a/lang/en.json
+++ b/lang/en.json
@@ -36,6 +36,16 @@
       "AutoFortification": {
         "Name": "Auto Fortification",
         "Hint": "Automatically prompt a Fortification flat check on critical hits"
+      },
+      "RemasterSheetMode": {
+        "Name": "Remaster Sheets",
+        "Hint": "Enable alternative color schemes for character and NPC sheets",
+        "Choices": {
+          "Off": "Off",
+          "RemasterLight": "Original (Remaster)",
+          "RemasterDark": "Dark Mode (Remaster)",
+          "RemasterRed": "Dark Mode (Red)"
+        }
       }
     },
     "QuickLootConfirmTitle": "Quick Loot",

--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -1,24 +1,31 @@
 Hooks.once("init", () => {
-  game.settings.register("pf2e-token-bar", "characterSheetStyle", {
-    name: "Character Sheet Style",
+  game.settings.register("pf2e-token-bar", "remasterSheetMode", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Hint"),
     scope: "client",
     config: true,
     type: String,
+    default: "off",
     choices: {
-      standard: "standard",
-      remaster: "remaster",
-      red: "red",
-      dark: "dark"
+      off: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.Off"),
+      remasterLight: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterLight"),
+      remasterDark: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterDark"),
+      remasterRed: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterRed"),
     },
-    default: "standard"
   });
 });
 
 Hooks.on("renderActorSheet", (_app, html) => {
-  const style = game.settings.get("pf2e-token-bar", "characterSheetStyle");
+  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
   const element = html[0];
   if (!element) return;
   element.classList.remove("dark-theme", "remaster", "red", "dark");
-  if (style !== "standard") element.classList.add("dark-theme", style);
+  if (mode === "remasterLight") {
+    element.classList.add("remaster");
+  } else if (mode === "remasterDark") {
+    element.classList.add("dark-theme", "remaster");
+  } else if (mode === "remasterRed") {
+    element.classList.add("dark-theme", "red");
+  }
 });
 


### PR DESCRIPTION
## Summary
- add client-side remaster sheet mode setting with multiple color options
- localize new setting in English and German

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f5abeda083278720ef8d886b1d57