### PR TITLE
Ensure remaster sheet classes apply to outer shell

### DIFF
--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -15,17 +15,11 @@ Hooks.once("init", () => {
   });
 });
 
-Hooks.on("renderActorSheet", (_app, html) => {
-  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
-  const element = html[0];
+Hooks.on("renderActorSheet", (app, html) => {
+  const style = game.settings.get("pf2e-token-bar", "remasterSheetMode");
+  const element = html.closest(".sheet.character")[0];
   if (!element) return;
-  element.classList.remove("dark-theme", "remaster", "red", "dark");
-  if (mode === "remasterLight") {
-    element.classList.add("remaster");
-  } else if (mode === "remasterDark") {
-    element.classList.add("dark-theme", "remaster");
-  } else if (mode === "remasterRed") {
-    element.classList.add("dark-theme", "red");
-  }
+  element.classList.remove("dark-theme", "remasterLight", "remasterDark", "remasterRed");
+  if (style !== "off") element.classList.add("dark-theme", style);
 });
 


### PR DESCRIPTION
## Summary
- simplify renderActorSheet hook to apply selected remaster style
- attach classes to `.sheet.character` so CSS variables cascade properly

## Testing
- `node --check scripts/remaster-sheets.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f68f16508327ae99ecd8b29622b1