### PR TITLE
Add remaster sheet theme variables

### DIFF
--- a/module.json
+++ b/module.json
@@ -23,7 +23,8 @@
     "scripts/remaster-sheets.js"
   ],
   "styles": [
-    "styles/token-bar.css"
+    "styles/token-bar.css",
+    "styles/remaster-sheets.css"
   ],
 
   "languages": [

--- a/styles/remaster-sheets.css
+++ b/styles/remaster-sheets.css
@@ -1,0 +1,16 @@
+/* Theme variables for remaster sheet variations */
+.dark-theme {
+  --pfui-main-color: #cfbda7;
+}
+
+/* Dark remaster palette */
+.remasterDark {
+  --primary-remaster: hsl(153, 100%, 8%);
+  --on-primary-remaster: #ffffff;
+}
+
+/* Red remaster palette */
+.remasterRed {
+  --primary-remaster: hsl(0, 65%, 15%);
+  --on-primary-remaster: #ffffff;
+}


### PR DESCRIPTION
## Summary
- add stylesheet defining variables for remaster dark and red palettes
- register new stylesheet in module manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f66dfb048327be471ccdf0d9766a