### PR TITLE
Implement NPC sheet theme support

### DIFF
--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -15,17 +15,26 @@ Hooks.once("init", () => {
   });
 });
 
-Hooks.on("renderActorSheet", (_app, html) => {
-  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
-  const element = html[0];
+const applySheetMode = (element, mode, useNpc) => {
   if (!element) return;
-  element.classList.remove("dark-theme", "remaster", "red", "dark");
+  element.classList.remove("dark-theme", "dark-npc-theme", "remaster", "red", "dark");
   if (mode === "remasterLight") {
-    element.classList.add("remaster");
+    if (useNpc) element.classList.add("dark-npc-theme", "remaster");
+    else element.classList.add("remaster");
   } else if (mode === "remasterDark") {
-    element.classList.add("dark-theme", "remaster");
+    element.classList.add(useNpc ? "dark-npc-theme" : "dark-theme", "remaster");
   } else if (mode === "remasterRed") {
-    element.classList.add("dark-theme", "red");
+    element.classList.add(useNpc ? "dark-npc-theme" : "dark-theme", "red");
   }
+};
+
+Hooks.on("renderCharacterSheetPF2e", (_app, html) => {
+  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
+  applySheetMode(html[0], mode, false);
+});
+
+Hooks.on("renderNPCSheetPF2e", (_app, html) => {
+  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
+  applySheetMode(html[0], mode, true);
 });
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -442,3 +442,18 @@
   justify-content:center;
   margin-top:4px;
 }
+
+/* NPC sheet theming */
+.actor.npc.dark-npc-theme .window-content {
+  background: #1e1e1e;
+  color: #ddd;
+}
+
+.actor.npc.dark-npc-theme.remaster .window-content {
+  background: #1e1e1e;
+}
+
+.actor.npc.dark-npc-theme.red .window-content {
+  background: #1e1e1e;
+  color: #ddd;
+}


### PR DESCRIPTION
## Summary
- add renderNPCSheetPF2e hook to apply dark-npc-theme with selected style
- share sheet mode logic between character and NPC sheets
- style dark NPC sheets via `.actor.npc` CSS rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f690c5248327814db14ba5093212