### PR TITLE
feat: update remaster sheet mode handling

### DIFF
--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -15,11 +15,26 @@ Hooks.once("init", () => {
   });
 });
 
-Hooks.on("renderActorSheet", (app, html) => {
-  const style = game.settings.get("pf2e-token-bar", "remasterSheetMode");
-  const element = html.closest(".sheet.character")[0];
+function applySheetMode(element, mode) {
   if (!element) return;
-  element.classList.remove("dark-theme", "remasterLight", "remasterDark", "remasterRed");
-  if (style !== "off") element.classList.add("dark-theme", style);
+
+  element.classList.remove(
+    "dark-theme",
+    "dark-npc-theme",
+    "remasterLight",
+    "remasterDark",
+    "remasterRed"
+  );
+
+  if (mode === "off") return;
+
+  const theme = element.classList.contains("npc") ? "dark-npc-theme" : "dark-theme";
+  element.classList.add(mode, theme);
+}
+
+Hooks.on("renderActorSheet", (app, html) => {
+  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
+  const element = html.closest(".sheet")[0];
+  applySheetMode(element, mode);
 });
 

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -177,7 +177,11 @@
   margin-top: 2px;
 }
 
-#pf2e-token-bar .pf2e-hero-point {
+/* Hero point colors adjust for remaster sheet modes */
+#pf2e-token-bar .pf2e-hero-point,
+.remasterLight #pf2e-token-bar .pf2e-hero-point,
+.remasterDark #pf2e-token-bar .pf2e-hero-point,
+.remasterRed #pf2e-token-bar .pf2e-hero-point {
   width: 8px;
   height: 8px;
   border: 1px solid gold;
@@ -185,7 +189,10 @@
   cursor: pointer;
 }
 
-#pf2e-token-bar .pf2e-hero-point.full {
+#pf2e-token-bar .pf2e-hero-point.full,
+.remasterLight #pf2e-token-bar .pf2e-hero-point.full,
+.remasterDark #pf2e-token-bar .pf2e-hero-point.full,
+.remasterRed #pf2e-token-bar .pf2e-hero-point.full {
   background: gold;
 }
 


### PR DESCRIPTION
## Summary
- add `applySheetMode` helper to apply chosen remaster mode and dark theme classes
- support remaster theme classes in token bar hero point styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f884d81883278e0d6713ae407787