### PR TITLE
Use PF2e actorSheetReady hook for sheet themes

### DIFF
--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -32,9 +32,9 @@ function applySheetMode(element, mode) {
   element.classList.add(mode, theme);
 }
 
-Hooks.on("renderActorSheet", (app, html) => {
+Hooks.on("pf2e.actorSheetReady", (app) => {
   const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
-  const element = html.closest(".sheet")[0];
+  const element = app.element?.[0] ?? app.element;
   applySheetMode(element, mode);
 });
 


### PR DESCRIPTION
## Summary
- Switch to PF2e's `pf2e.actorSheetReady` event for applying remaster sheet classes
- Use the sheet application's `element` as the root instead of jQuery lookup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fdf957cc8327a80d64e40ad0c509