### PR TITLE
Reapply sheet mode on setting change

### DIFF
--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -12,6 +12,14 @@ Hooks.once("init", () => {
       remasterDark: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterDark"),
       remasterRed: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterRed"),
     },
+    onChange: (value) => {
+      for (const app of Object.values(ui.windows)) {
+        if (app instanceof ActorSheetPF2e) {
+          const element = app.element?.[0] ?? app.element;
+          applySheetMode(element, value);
+        }
+      }
+    },
   });
 });
 
@@ -32,7 +40,7 @@ function applySheetMode(element, mode) {
   element.classList.add(mode, theme);
 }
 
-Hooks.on("pf2e.actorSheetReady", (app) => {
+Hooks.on("renderActorSheetPF2e", (app) => {
   const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
   const element = app.element?.[0] ?? app.element;
   applySheetMode(element, mode);


### PR DESCRIPTION
## Summary
- reapply remaster sheet styles when the setting is toggled
- use renderActorSheetPF2e hook instead of pf2e.actorSheetReady

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72b5bc67883279e6a0d14e06e8fd9