### PR TITLE
Add remaster light and dark NPC theme variables

### DIFF
--- a/styles/remaster-sheets.css
+++ b/styles/remaster-sheets.css
@@ -5,6 +5,7 @@
 
 /* Light remaster palette */
 .remasterLight {
+  --pfui-main-color: #cfbda7;
   --primary-remaster: hsl(153, 100%, 88%);
   --on-primary-remaster: #000000;
 }
@@ -18,5 +19,12 @@
 /* Red remaster palette */
 .remasterRed {
   --primary-remaster: hsl(0, 65%, 15%);
+  --on-primary-remaster: #ffffff;
+}
+
+/* Dark NPC palette */
+.dark-npc-theme {
+  --pfui-main-color: #cfbda7;
+  --primary-remaster: hsl(153, 100%, 8%);
   --on-primary-remaster: #ffffff;
 }


### PR DESCRIPTION
## Summary
- add pf2e color variables for remaster light theme
- introduce dark NPC theme with matching remaster variables

## Testing
- `node - <<'NODE'
const fs=require('fs');
const css=fs.readFileSync('styles/remaster-sheets.css','utf8');
for(const cls of ['remasterLight','dark-npc-theme','remasterDark','remasterRed']){
  const re=new RegExp(`\\.${cls}\\s*{[^}]*}`);
  console.log(cls, re.test(css)?'found':'missing');
}
NODE`
- `node - <<'NODE'
const fs=require('fs');
const css=fs.readFileSync('styles/remaster-sheets.css','utf8');
function getVars(cls){
  const match=css.match(new RegExp(`\\.${cls}\\s*{([^}]*)}`));
  if(!match) return {};
  const vars={};
  for(const line of match[1].split(';')){
    const [prop,val]=line.split(':').map(s=>s.trim());
    if(prop && prop.startsWith('--')) vars[prop]=val;
  }
  return vars;
}
for(const cls of ['remasterLight','dark-npc-theme']){
  console.log(cls,getVars(cls));
}
NODE`
- `npm test 2>&1 | tee /tmp/test.log` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7df1371148327b8105ab8d8e26d41