### PR TITLE
Fix remaster sheet styling for Character and NPC sheets

### DIFF
--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -40,7 +40,13 @@ function applySheetMode(element, mode) {
   element.classList.add(mode, theme);
 }
 
-Hooks.on("renderActorSheetPF2e", (app) => {
+Hooks.on("renderCharacterSheetPF2e", (app) => {
+  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
+  const element = app.element?.[0] ?? app.element;
+  applySheetMode(element, mode);
+});
+
+Hooks.on("renderNPCSheetPF2e", (app) => {
   const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
   const element = app.element?.[0] ?? app.element;
   applySheetMode(element, mode);


### PR DESCRIPTION
## Summary
- apply remaster sheet mode when PF2e character and NPC sheets render

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f5c0ac9c83278994a51294d32fa7