### PR TITLE
Add Shadow rune Stealth automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The **PF2e Token-Bar** extends Foundry VTT with a compact display of all relevan
 2. [Party Mode](#party-mode)
 3. [Combat Mode](#combat-mode)
 4. [Ring Menu](#ring-menu)
-5. [Fortification Automation](#fortification-automation)
+5. [Rune Automation](#rune-automation)
 6. [Settings & Controls](#settings--controls)
 7. [Hotkeys](#hotkeys)
 8. [Debugging](#debugging)
@@ -89,13 +89,20 @@ Right-click a token to open a radial menu:
 
 ---
 
-## Fortification Automation
+## Rune Automation
 
-Automatically handle Fortification armor runes on critical hits.
+Automatically handle armor property runes.
+
+### Fortification
 
 - Enable the **Auto Fortification** setting under *Settings → Module Settings → PF2e Token-Bar*.
 - When a creature with a **Fortification** or **Greater Fortification** rune suffers a critical hit, a chat button prompts a **flat check** (DC 17 or DC 14 for greater fortification).
 - Success downgrades the critical hit to normal damage and rolls the weapon's damage automatically.
+
+### Shadow
+
+- Enable the **Auto Shadow** setting under *Settings → Module Settings → PF2e Token-Bar*.
+- When wearing armor with a **Shadow**, **Greater Shadow**, or **Major Shadow** rune, a +1/+2/+3 item bonus to Stealth checks is automatically applied.
 
 ---
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -37,6 +37,10 @@
         "Name": "Fortification-Automatisierung",
         "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"
       },
+      "AutoShadow": {
+        "Name": "Schatten-Automatisierung",
+        "Hint": "Wendet automatisch Schattenrune-Boni auf Heimlichkeit an"
+      },
       "RemasterSheetMode": {
         "Name": "Remaster-Sheets",
         "Hint": "Aktiviert alternative Farbgebungen für Charakter- und NSC-Sheets",

--- a/lang/en.json
+++ b/lang/en.json
@@ -37,6 +37,10 @@
         "Name": "Auto Fortification",
         "Hint": "Automatically prompt a Fortification flat check on critical hits"
       },
+      "AutoShadow": {
+        "Name": "Auto Shadow",
+        "Hint": "Automatically apply Shadow rune bonuses to Stealth"
+      },
       "RemasterSheetMode": {
         "Name": "Remaster Sheets",
         "Hint": "Enable alternative color schemes for character and NPC sheets",

--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -7,6 +7,41 @@ Hooks.once("init", () => {
     type: Boolean,
     default: false,
   });
+
+  game.settings.register("pf2e-token-bar", "autoShadow", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.AutoShadow.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.AutoShadow.Hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+});
+
+Hooks.on("pf2e.prepareActorData", (actor) => {
+  if (!game.settings.get("pf2e-token-bar", "autoShadow")) return;
+
+  const options = actor.rollOptions.all;
+  const bonus = options["armor:rune:property:major-shadow"]
+    ? 3
+    : options["armor:rune:property:greater-shadow"]
+    ? 2
+    : options["armor:rune:property:shadow"]
+    ? 1
+    : 0;
+  if (!bonus) return;
+
+  const { FlatModifier } = game.pf2e.rules;
+  const modifier = new FlatModifier({
+    slug: "shadow-rune",
+    label: "Shadow Rune",
+    selector: "stealth",
+    type: "item",
+    value: bonus,
+  });
+
+  actor.synthetics.statisticsModifiers.stealth ??= [];
+  actor.synthetics.statisticsModifiers.stealth.push(modifier);
 });
 
 Hooks.on("createChatMessage", async (message) => {


### PR DESCRIPTION
## Summary
- add Auto Shadow setting and apply Shadow rune Stealth bonuses
- localize Auto Shadow setting
- document rune automation in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c173c24f908327b2731a143251738b