### PR TITLE
Handle fortification via inline check and PF2e roll hook

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -110,6 +110,10 @@
       "Moderate": "Mittel",
       "Severe": "Schwer",
       "Extreme": "Extrem"
+    },
+    "Fortification": {
+      "Check": "Fortifikations-Flatcheck (SG {dc})",
+      "Success": "Kritischer Treffer zu normalem Schaden herabgestuft."
     }
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -110,6 +110,10 @@
       "Moderate": "Moderate",
       "Severe": "Severe",
       "Extreme": "Extreme"
+    },
+    "Fortification": {
+      "Check": "Fortification Flat Check (DC {dc})",
+      "Success": "Critical downgraded to normal damage."
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace fortification button with PF2e inline `@Check` link
- Process fortification checks through new `pf2e.check.roll` hook
- Localize fortification messages in English and German

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68c17672625c8327bfbda18e1bdce562