### PR TITLE
feat: add Shadow Rune roll toggle

### DIFF
--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -38,6 +38,8 @@ Hooks.on("pf2e.prepareActorData", (actor) => {
     selector: "stealth",
     type: "item",
     value: bonus,
+    enabled: false,
+    custom: true,
   });
 
   actor.synthetics.statisticsModifiers.stealth ??= [];


### PR DESCRIPTION
## Summary
- allow Shadow Rune bonus to be toggled in the Stealth roll dialog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17dd914308327ab05f7b1ccc328c6