### PR TITLE
feat: add shadow rune stealth toggle

### DIFF
--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -22,23 +22,51 @@ Hooks.on("pf2e.prepareActorData", (actor) => {
   if (!game.settings.get("pf2e-token-bar", "autoShadow")) return;
 
   const options = actor.rollOptions.all;
-  const bonus = options["armor:rune:property:major-shadow"]
-    ? 3
+  const rune = options["armor:rune:property:major-shadow"]
+    ? {
+        predicate: "armor:rune:property:major-shadow",
+        option: "major-shadow-rune",
+        label: "PF2E.ArmorRunePropertyMajorShadow.ItemBonus",
+        bonus: 3,
+      }
     : options["armor:rune:property:greater-shadow"]
-    ? 2
+    ? {
+        predicate: "armor:rune:property:greater-shadow",
+        option: "greater-shadow-rune",
+        label: "PF2E.ArmorRunePropertyGreaterShadow.ItemBonus",
+        bonus: 2,
+      }
     : options["armor:rune:property:shadow"]
-    ? 1
-    : 0;
-  if (!bonus) return;
+    ? {
+        predicate: "armor:rune:property:shadow",
+        option: "shadow-rune",
+        label: "PF2E.ArmorRunePropertyShadow.ItemBonus",
+        bonus: 1,
+      }
+    : null;
+  if (!rune) return;
+
+  actor.synthetics.toggles["skill-check"] ??= {};
+  actor.synthetics.toggles["skill-check"][rune.option] = {
+    itemId: `pf2e-token-bar.${rune.option}`,
+    label: game.i18n.localize(rune.label),
+    placement: "actions",
+    domain: "skill-check",
+    option: rune.option,
+    suboptions: [],
+    alwaysActive: false,
+    checked: false,
+    enabled: true,
+  };
 
   const { FlatModifier } = game.pf2e.rules;
   const modifier = new FlatModifier({
-    slug: "shadow-rune",
-    label: "Shadow Rune",
+    slug: rune.option,
+    label: game.i18n.localize(rune.label),
     selector: "stealth",
     type: "item",
-    value: bonus,
-    enabled: false,
+    value: rune.bonus,
+    predicate: [rune.predicate, rune.option],
     custom: true,
   });
 


### PR DESCRIPTION
## Summary
- add toggles for Shadow, Greater Shadow, and Major Shadow runes
- grant Stealth item bonus only when rune exists and toggle is active

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c189c72d908327be859aeb32ff491e