### PR TITLE
feat: optional persistent turn marker overlay

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -33,6 +33,10 @@
         "Name": "Begegnungs-Scrollbalken",
         "Hint": "Wenn deaktiviert, erweitert sich die Leiste nach rechts ohne Scrollen"
       },
+      "KeepTurnOverlay": {
+        "Name": "Turn-Marker beibehalten",
+        "Hint": "Belässt die Kampfrunden-Markierung dauerhaft auf dem aktiven Token"
+      },
       "AutoFortification": {
         "Name": "Fortification-Automatisierung",
         "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"

--- a/lang/en.json
+++ b/lang/en.json
@@ -33,6 +33,10 @@
         "Name": "Encounter scrollbar",
         "Hint": "When disabled, the bar extends to the right without scrolling"
       },
+      "KeepTurnOverlay": {
+        "Name": "Keep Turn Overlay",
+        "Hint": "Keep the combat turn marker visible on the active token"
+      },
       "AutoFortification": {
         "Name": "Auto Fortification",
         "Hint": "Automatically prompt a Fortification flat check on critical hits"


### PR DESCRIPTION
## Summary
- add `keepTurnOverlay` setting to preserve combat turn marker
- skip overlay reset when delaying or resuming turns if setting enabled
- refresh overlay each combat turn when option is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c49faa8f1883279ffcfcf4af89cdd2