### PR TITLE
Make encounter mode setting global

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -92,7 +92,7 @@ Hooks.once("init", () => {
   game.settings.register("pf2e-token-bar", "encounterMode", {
     name: game.i18n.localize("PF2ETokenBar.Settings.EncounterMode.Name"),
     hint: game.i18n.localize("PF2ETokenBar.Settings.EncounterMode.Hint"),
-    scope: "client",
+    scope: "world",
     config: true,
     type: Boolean,
     default: true,
@@ -603,7 +603,7 @@ class PF2ETokenBar {
     });
     controls.appendChild(lockBtn);
 
-    if (encounterAvailable) {
+    if (encounterAvailable && game.user.isGM) {
       const encounterToggleBtn = document.createElement("button");
       const updateEncounterToggleBtn = () => {
         const current = game.settings.get("pf2e-token-bar", "encounterMode");


### PR DESCRIPTION
## Summary
- change the encounter mode setting to use world scope so the GM toggle applies to all clients
- only render the encounter mode toggle button for GMs to avoid unauthorized setting updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd32163f308327b9bdde38531f3508