### PR TITLE
Ensure turn marker always reapplies

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -33,10 +33,6 @@
         "Name": "Begegnungs-Scrollbalken",
         "Hint": "Wenn deaktiviert, erweitert sich die Leiste nach rechts ohne Scrollen"
       },
-      "KeepTurnOverlay": {
-        "Name": "Turn-Marker beibehalten",
-        "Hint": "Belässt die Kampfrunden-Markierung dauerhaft auf dem aktiven Token"
-      },
       "AutoFortification": {
         "Name": "Fortification-Automatisierung",
         "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"

--- a/lang/en.json
+++ b/lang/en.json
@@ -33,10 +33,6 @@
         "Name": "Encounter scrollbar",
         "Hint": "When disabled, the bar extends to the right without scrolling"
       },
-      "KeepTurnOverlay": {
-        "Name": "Keep Turn Overlay",
-        "Hint": "Keep the combat turn marker visible on the active token"
-      },
       "AutoFortification": {
         "Name": "Auto Fortification",
         "Hint": "Automatically prompt a Fortification flat check on critical hits"


### PR DESCRIPTION
## Summary
- remove the unused Keep Turn Overlay setting and localization entries
- add a helper to reapply the combat overlay when turns advance
- always swap to and restore the hourglass overlay when delaying or resuming

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce758f6ab083278574386fd94d5b9c