### PR TITLE
Add GM control to clear effects from zero HP tokens

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -56,6 +56,8 @@
     "QuickLootConfirmContent": "Beute besiegter NSC übertragen und Beute-Akteur öffnen?",
     "HealAll": "Alle heilen",
     "HealAllConfirm": "Alle auf volle HP setzen?",
+    "ClearZeroHpEffects": "Effekte bei 0 HP entfernen",
+    "ClearZeroHpEffectsConfirm": "Alle aktiven Effekte und Zustände von Tokens mit 0 Trefferpunkten entfernen?",
     "XP": "EP",
     "GiveXPTitle": "EP vergeben",
     "GiveXPLabel": "Menge",

--- a/lang/en.json
+++ b/lang/en.json
@@ -56,6 +56,8 @@
     "QuickLootConfirmContent": "Transfer defeated NPC loot and open the Loot actor?",
     "HealAll": "Heal All",
     "HealAllConfirm": "Set everyone to full HP?",
+    "ClearZeroHpEffects": "Clear 0 HP Effects",
+    "ClearZeroHpEffectsConfirm": "Remove all active effects and conditions from tokens at 0 HP?",
     "XP": "XP",
     "GiveXPTitle": "Award XP",
     "GiveXPLabel": "Amount",


### PR DESCRIPTION
## Summary
- add a GM-only button to the token bar to clear effects from tokens at 0 HP
- implement PF2ETokenBar.clearZeroHpEffects with a confirmation dialog and safe deletions
- localize the new button and confirmation strings in English and German

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce784ddfd48327a717ba68109982c0