### PR TITLE
Use Foundry V13 turn marker API

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -1128,10 +1128,21 @@ class PF2ETokenBar {
   }
 
   static async enforceTurnMarker() {
-    const token = game.combat?.combatant?.token?.object;
+    const combatant = game.combat?.combatant;
+    if (!combatant) return;
+
+    const tokensLayer = canvas?.tokens;
+    const token =
+      combatant.token?.object ??
+      (combatant.tokenId && tokensLayer ? tokensLayer.get(combatant.tokenId) : null);
     if (!token) return;
+
     try {
-      if (token.document.overlayEffect !== CONFIG.controlIcons.combat) {
+      const turnMarker = token.turnMarker;
+      if (turnMarker?.draw) {
+        token.renderFlags?.set?.("refreshTurnMarker", true);
+        await turnMarker.draw();
+      } else if (token.document?.overlayEffect !== CONFIG.controlIcons.combat) {
         await token.document.update({ overlayEffect: CONFIG.controlIcons.combat }, { diff: false });
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- refresh the active token turn marker through the new Token.turnMarker helper when available
- fall back to the classic combat overlay icon only if the new API is not present
- resolve the active token from the combatant or the token layer for better reliability

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce8c0e1b888327a713f6bb712dfda3