### PR TITLE
Add configurable turn marker icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ Under **Settings → Module Settings → PF2e Token-Bar**:
 - **Encounter mode** – when enabled (default), the bar switches to combatants during encounters and shows round counter and difficulty.
 - **Encounter scrollbar** – when disabled, the bar extends to the right without scrolling.
 - **Quick loot** – automatically transfer defeated NPC loot and open the Loot actor when combat ends.
+- **Turn marker icons (party/NPC)** – choose overlay icons for party members and NPCs when Foundry cannot draw the default turn marker. Accepts preset keywords (`default`, `target`, `skull`, `hourglass`) or a custom image path via the file picker.
+
+### Custom turn markers
+
+- Preset keywords expand to Foundry's built-in icons: `default`/`combat` (crossed swords), `target`/`crosshairs`, `skull`/`defeated`, and `hourglass`.
+- You can also enter a path to any image in the user data directory, such as `icons/custom/party-marker.png` or `worlds/<your-world>/art/token-overlay.webp`. The settings dialog includes a file picker button to browse for files.
+- When a combatant delays and resumes their turn, PF2e Token-Bar remembers and restores the previously configured marker so that custom overlays persist.
 
 ---
 

--- a/lang/de.json
+++ b/lang/de.json
@@ -33,6 +33,14 @@
         "Name": "Begegnungs-Scrollbalken",
         "Hint": "Wenn deaktiviert, erweitert sich die Leiste nach rechts ohne Scrollen"
       },
+      "PartyTurnMarkerIcon": {
+        "Name": "Rundenmarker-Symbol (Gruppe)",
+        "Hint": "Symbolpfad oder Vorgabename (default, target, skull, hourglass). Leer lassen, um den Foundry-Standardmarker zu verwenden."
+      },
+      "NPCTurnMarkerIcon": {
+        "Name": "Rundenmarker-Symbol (NSC)",
+        "Hint": "Symbolpfad oder Vorgabename (default, target, skull, hourglass). Leer lassen, um den Foundry-Standardmarker zu verwenden."
+      },
       "AutoFortification": {
         "Name": "Fortification-Automatisierung",
         "Hint": "Bietet bei kritischen Treffern automatisch einen Fortification-Flatcheck an"

--- a/lang/en.json
+++ b/lang/en.json
@@ -33,6 +33,14 @@
         "Name": "Encounter scrollbar",
         "Hint": "When disabled, the bar extends to the right without scrolling"
       },
+      "PartyTurnMarkerIcon": {
+        "Name": "Party turn marker icon",
+        "Hint": "Icon path or preset name (default, target, skull, hourglass). Leave blank to use Foundry's combat marker."
+      },
+      "NPCTurnMarkerIcon": {
+        "Name": "NPC turn marker icon",
+        "Hint": "Icon path or preset name (default, target, skull, hourglass). Leave blank to use Foundry's combat marker."
+      },
       "AutoFortification": {
         "Name": "Auto Fortification",
         "Hint": "Automatically prompt a Fortification flat check on critical hits"


### PR DESCRIPTION
## Summary
- add world settings that let GMs pick separate party and NPC turn marker icons, including localization strings
- resolve the appropriate marker icon when enforcing, delaying, or resuming turns so customized overlays are restored
- document preset keywords and custom marker paths in the README for easier configuration

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce932206d48327aa85f03811eaadeb