### PR TITLE
Preserve dead condition when clearing zero HP effects

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -1168,6 +1168,9 @@ class PF2ETokenBar {
       ];
       for (const effect of effects) {
         if (!effect || effect.disabled || effect.isExpired) continue;
+        const slug = typeof effect.slug === "string" ? effect.slug.toLowerCase() : "";
+        const statusId = typeof effect.statusId === "string" ? effect.statusId.toLowerCase() : "";
+        if (slug === "dead" || statusId === "dead") continue;
         const id = effect.id ?? effect._id;
         if (typeof id === "string" && id.length) effectIds.add(id);
       }


### PR DESCRIPTION
## Summary
- skip collecting the PF2E dead condition when clearing effects on actors at 0 HP

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1bade3cc8327b257f390b3e9f598