### PR TITLE
Add PF2e Points Tracker button to token bar

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -122,6 +122,7 @@
     "Lock": "Sperren",
     "Unlock": "Entsperren",
     "QuestLog": "Questlog",
+    "PointsTracker": "Punktetracker",
     "EnableEncounterMode": "Begegnungsmodus aktivieren",
     "DisableEncounterMode": "Begegnungsmodus deaktivieren",
     "HeroPoints": "Heldenpunkte",

--- a/lang/en.json
+++ b/lang/en.json
@@ -122,6 +122,7 @@
     "Lock": "Lock",
     "Unlock": "Unlock",
     "QuestLog": "Quest Log",
+    "PointsTracker": "Points Tracker",
     "EnableEncounterMode": "Enable Encounter Mode",
     "DisableEncounterMode": "Disable Encounter Mode",
     "HeroPoints": "Hero Points",

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -834,6 +834,37 @@ class PF2ETokenBar {
     });
     controls.appendChild(questLogBtn);
 
+    const pointsTrackerBtn = document.createElement("button");
+    pointsTrackerBtn.innerHTML = '<i class="fas fa-flask"></i>';
+    const pointsTrackerTitle = game.i18n.localize("PF2ETokenBar.PointsTracker");
+    pointsTrackerBtn.title = pointsTrackerTitle;
+    pointsTrackerBtn.setAttribute("aria-label", pointsTrackerTitle);
+    const getPointsTrackerOpener = () => {
+      if (typeof game.pf2ePointsTracker?.open === "function") {
+        return () => game.pf2ePointsTracker.open();
+      }
+      if (typeof globalThis.openResearchTracker === "function") {
+        return () => globalThis.openResearchTracker();
+      }
+      return null;
+    };
+    const updatePointsTrackerBtn = () => {
+      const pointsTrackerModule = game.modules.get("pf2e-points-tracker");
+      const opener = getPointsTrackerOpener();
+      pointsTrackerBtn.disabled = !(pointsTrackerModule?.active && opener);
+    };
+    updatePointsTrackerBtn();
+    pointsTrackerBtn.addEventListener("click", () => {
+      const opener = getPointsTrackerOpener();
+      if (!opener) return;
+      try {
+        opener();
+      } catch (err) {
+        console.error("PF2ETokenBar | failed to open PF2e Points Tracker", err);
+      }
+    });
+    controls.appendChild(pointsTrackerBtn);
+
     if (encounterAvailable && game.user.isGM) {
       const encounterToggleBtn = document.createElement("button");
       const updateEncounterToggleBtn = () => {


### PR DESCRIPTION
## Summary
- add a shortcut button on the token bar to open the PF2e Points Tracker module
- localize the new control in English and German

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900acddda0c8327a99a71d51e3625a2