### PR TITLE
Add Auto NPC Initiative world setting with English and German locales

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -25,6 +25,10 @@
         "Name": "Initiativeabfrage bei 0 TP",
         "Hint": "Fragt, ob ein Gruppenmitglied bei 0 TP direkt vor den Angreifer in der Initiative einsortiert werden soll und erlaubt einen eigenen Wert."
       },
+      "AutoNpcInitiative": {
+        "Name": "NSC-Initiative automatisch würfeln",
+        "Hint": "Würfelt bei Bedarf automatisch die Initiative für NSC."
+      },
       "EncounterModeAvailable": {
         "Name": "Begegnungsmodus verfügbar",
         "Hint": "Erlaubt die Verwendung des Begegnungsmodus und zeigt den Umschalter an"

--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,10 @@
         "Name": "Prompt Initiative Change at 0 HP",
         "Hint": "When a party member drops to 0 HP, ask to move them just before the attacker in initiative and allow entering a custom value."
       },
+      "AutoNpcInitiative": {
+        "Name": "Auto Roll NPC Initiative",
+        "Hint": "Automatically roll initiative for NPCs when needed."
+      },
       "EncounterModeAvailable": {
         "Name": "Encounter Mode Available",
         "Hint": "Allow use of encounter mode features and show the encounter toggle"

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -80,6 +80,14 @@ Hooks.once("init", () => {
     type: Boolean,
     default: false,
   });
+  game.settings.register("pf2e-token-bar", "autoNpcInitiative", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.AutoNpcInitiative.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.AutoNpcInitiative.Hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
   game.settings.register("pf2e-token-bar", "encounterModeAvailable", {
     name: game.i18n.localize("PF2ETokenBar.Settings.EncounterModeAvailable.Name"),
     hint: game.i18n.localize("PF2ETokenBar.Settings.EncounterModeAvailable.Hint"),
@@ -1890,4 +1898,3 @@ Hooks.on("deleteCombat", () => {
   PF2ETokenBar.clearZeroHpTracking();
   PF2ETokenBar.render();
 });
-


### PR DESCRIPTION
### Motivation
- Provide a configurable option to automatically roll initiative for NPCs when needed.
- Expose the option as a world-level setting so GMs can enable/disable it for a campaign.

### Description
- Register a new setting `game.settings.register("pf2e-token-bar", "autoNpcInitiative", ...)` with `scope: "world"`, `config: true`, `type: Boolean`, and `default: false` in `scripts/token-bar.js`.
- Add localization entries for the setting under `PF2ETokenBar.Settings.AutoNpcInitiative` in `lang/en.json` and `lang/de.json` with `Name` and `Hint` strings.
- Changes touch `scripts/token-bar.js`, `lang/en.json`, and `lang/de.json` to add the new setting and its labels.

### Testing
- No automated tests were executed for this change.
- Basic repository commands (`git status`, `git commit`) were run during the rollout to record the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a184761083278f51c09995607b85)