### PR TITLE
Modernize PF2e Token Bar for Foundry V14

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -152,6 +152,10 @@
       "Label": "Initiative",
       "Confirm": "Verschieben",
       "UnknownAttacker": "dem Angreifer"
-    }
+    },
+    "Confirm": "OK",
+    "LootPermission": "Du hast keine Berechtigung, den Beute-Akteur zu bearbeiten.",
+    "ActorPermission": "Du hast keine Berechtigung, diesen Akteur zu bearbeiten.",
+    "DropFailed": "Gegenstand konnte nicht abgelegt werden."
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -152,6 +152,10 @@
       "Label": "Initiative",
       "Confirm": "Move",
       "UnknownAttacker": "the attacker"
-    }
+    },
+    "Confirm": "OK",
+    "LootPermission": "You do not have permission to modify the Loot actor.",
+    "ActorPermission": "You do not have permission to modify this actor.",
+    "DropFailed": "Failed to drop item."
   }
 }

--- a/module.json
+++ b/module.json
@@ -4,14 +4,17 @@
   "description": "Displays tokens from the active party and allows roll requests",
   "version": "2.0.2",
   "compatibility": {
-    "minimum": "13",
-    "verified": "13"
+    "minimum": "14",
+    "verified": "14"
   },
-
-
-  "foundryVersion": "11",
-
-  "systems": ["pf2e"],
+  "relationships": {
+    "systems": [
+      {
+        "id": "pf2e",
+        "type": "system"
+      }
+    ]
+  },
   "authors": [
     {
       "name": "Kazgul"

--- a/scripts/integrations/optional-modules.js
+++ b/scripts/integrations/optional-modules.js
@@ -1,0 +1,35 @@
+export class QuestLogIntegration {
+  static get active() {
+    return game.modules.get("forien-quest-log")?.active === true;
+  }
+
+  static open() {
+    if (!this.active) return false;
+    Hooks.callAll("ForienQuestLog.Open.QuestLog");
+    return true;
+  }
+}
+
+export class PointsTrackerIntegration {
+  static get active() {
+    return game.modules.get("pf2e-points-tracker")?.active === true;
+  }
+
+  static get opener() {
+    if (!this.active) return null;
+    if (typeof game.pf2ePointsTracker?.open === "function") {
+      return () => game.pf2ePointsTracker.open();
+    }
+    if (typeof globalThis.openResearchTracker === "function") {
+      return () => globalThis.openResearchTracker();
+    }
+    return null;
+  }
+
+  static open() {
+    const open = this.opener;
+    if (!open) return false;
+    open();
+    return true;
+  }
+}

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -1,0 +1,45 @@
+const MODULE_ID = "pf2e-token-bar";
+const warnedApis = new Set();
+
+function warnOnce(api) {
+  if (warnedApis.has(api)) return;
+  warnedApis.add(api);
+  console.warn(`${MODULE_ID} | PF2e ${api} API unavailable`);
+}
+
+/** The deliberately small boundary around PF2e's public, version-sensitive APIs. */
+export class PF2eAdapter {
+  static getParty() {
+    return game.actors?.party ?? null;
+  }
+
+  static getPartyMembers() {
+    return Array.from(this.getParty()?.members ?? []);
+  }
+
+  static requestCheck(actors) {
+    const checkPrompt = game.pf2e?.gm?.checkPrompt;
+    if (typeof checkPrompt !== "function") {
+      warnOnce("gm.checkPrompt");
+      return false;
+    }
+    checkPrompt({ actors });
+    return true;
+  }
+
+  static async restForTheNight(actors) {
+    const rest = game.pf2e?.actions?.restForTheNight;
+    if (typeof rest !== "function") {
+      warnOnce("actions.restForTheNight");
+      return false;
+    }
+    await rest({ actors });
+    return true;
+  }
+
+  static getConditionManager() {
+    const manager = game.pf2e?.ConditionManager;
+    if (!manager) warnOnce("ConditionManager");
+    return manager ?? null;
+  }
+}

--- a/scripts/integrations/workbench.js
+++ b/scripts/integrations/workbench.js
@@ -1,0 +1,30 @@
+const MODULE_ID = "xdy-pf2e-workbench";
+
+export class WorkbenchIntegration {
+  static get active() {
+    return game.modules.get(MODULE_ID)?.active === true;
+  }
+
+  static async executeMacro(macroName, ...args) {
+    if (!this.active) return false;
+
+    const worldMacro = game.macros?.getName?.(macroName)
+      ?? game.macros?.find(document => document?.name === macroName);
+    if (worldMacro?.execute) {
+      await worldMacro.execute(...args);
+      return true;
+    }
+
+    for (const pack of game.packs.filter(pack => pack.documentName === "Macro")) {
+      const index = await pack.getIndex();
+      const entry = index.find(item => item.name === macroName);
+      if (!entry) continue;
+      const macro = await pack.getDocument(entry._id);
+      if (!macro?.execute) continue;
+      await macro.execute(...args);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -1,5 +1,8 @@
+const MODULE_ID = "pf2e-token-bar";
+const THEME_CLASSES = ["dark-theme", "dark-npc-theme", "remasterLight", "remasterDark", "remasterRed"];
+
 Hooks.once("init", () => {
-  game.settings.register("pf2e-token-bar", "remasterSheetMode", {
+  game.settings.register(MODULE_ID, "remasterSheetMode", {
     name: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Name"),
     hint: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Hint"),
     scope: "client",
@@ -12,43 +15,30 @@ Hooks.once("init", () => {
       remasterDark: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterDark"),
       remasterRed: game.i18n.localize("PF2ETokenBar.Settings.RemasterSheetMode.Choices.RemasterRed"),
     },
-    onChange: (value) => {
-      for (const app of Object.values(ui.windows)) {
-        if (app instanceof ActorSheetPF2e) {
-          const element = app.element?.[0] ?? app.element;
-          applySheetMode(element, value);
-        }
-      }
-    },
+    onChange: applyModeToRenderedSheets,
   });
 });
 
 function applySheetMode(element, mode) {
-  if (!element) return;
-
-  element.classList.remove(
-    "dark-theme",
-    "dark-npc-theme",
-    "remasterLight",
-    "remasterDark",
-    "remasterRed"
-  );
-
+  if (!(element instanceof HTMLElement)) return;
+  element.classList.remove(...THEME_CLASSES);
   if (mode === "off") return;
 
-  const theme = element.classList.contains("npc") ? "dark-npc-theme" : "dark-theme";
-  element.classList.add(mode, theme);
+  const isNpc = element.classList.contains("npc") || element.matches('[data-document-type="npc"]');
+  element.classList.add(mode, isNpc ? "dark-npc-theme" : "dark-theme");
 }
 
-Hooks.on("renderCharacterSheetPF2e", (app) => {
-  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
-  const element = app.element?.[0] ?? app.element;
-  applySheetMode(element, mode);
-});
+function applyModeToRenderedSheets(mode) {
+  // Settings changes only need the live DOM; this avoids ui.windows and PF2e sheet globals.
+  for (const element of document.querySelectorAll(".application.actor.sheet, .app.actor.sheet")) {
+    applySheetMode(element, mode);
+  }
+}
 
-Hooks.on("renderNPCSheetPF2e", (app) => {
-  const mode = game.settings.get("pf2e-token-bar", "remasterSheetMode");
-  const element = app.element?.[0] ?? app.element;
-  applySheetMode(element, mode);
-});
+function themeRenderedSheet(application) {
+  const mode = game.settings.get(MODULE_ID, "remasterSheetMode");
+  applySheetMode(application.element, mode);
+}
 
+Hooks.on("renderCharacterSheetPF2e", themeRenderedSheet);
+Hooks.on("renderNPCSheetPF2e", themeRenderedSheet);

--- a/scripts/ring-menu.js
+++ b/scripts/ring-menu.js
@@ -1,3 +1,6 @@
+import { PF2eAdapter } from "./integrations/pf2e.js";
+import { ModuleDialog } from "./ui/dialogs.js";
+
 export class PF2ERingMenu {
   static element = null;
   static token = null;
@@ -126,7 +129,7 @@ export class PF2ERingMenu {
 
   static async _openConditionMenu(token) {
     try {
-      const manager = game.pf2e?.ConditionManager;
+      const manager = PF2eAdapter.getConditionManager();
       if (manager) {
         const conditions = manager.conditionsSlugs
           .map(slug => {
@@ -139,16 +142,16 @@ export class PF2ERingMenu {
           .map(({ slug, name }) => `<option value="${slug}">${name}</option>`)
           .join('');
         const content = `<form><select name="condition">${options}</select></form>`;
-        const slug = await Dialog.prompt({
+        const slug = await ModuleDialog.prompt({
           title: game.i18n?.localize('PF2ETokenBar.Condition') || 'Condition',
           content,
-          label: 'OK',
-          callback: html => html[0].querySelector('[name=condition]').value,
+          label: game.i18n.localize("PF2ETokenBar.Confirm"),
+          callback: element => element.querySelector('[name="condition"]')?.value,
         });
         if (slug) await token.actor?.toggleCondition(slug);
       } else if (token?.hud?.render) {
         await token.hud.render(true);
-        token.hud.element.find('.status-effects').click();
+        token.hud.element?.querySelector('.status-effects')?.click();
       }
     } catch (err) {
       console.error('PF2ERingMenu | condition menu error', err);

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -1,4 +1,9 @@
 import { PF2ERingMenu } from "./ring-menu.js";
+import { PF2eAdapter } from "./integrations/pf2e.js";
+import { WorkbenchIntegration } from "./integrations/workbench.js";
+import { PointsTrackerIntegration, QuestLogIntegration } from "./integrations/optional-modules.js";
+import { TokenProvider } from "./token-bar/token-provider.js";
+import { ModuleDialog } from "./ui/dialogs.js";
 
 Hooks.once("init", () => {
   game.settings.register("pf2e-token-bar", "position", {
@@ -348,12 +353,12 @@ class PF2ETokenBar {
 
     let initiative = null;
     try {
-      initiative = await Dialog.prompt({
+      initiative = await ModuleDialog.prompt({
         title: game.i18n.localize("PF2ETokenBar.ZeroHpPrompt.Title"),
         content,
         label: game.i18n.localize("PF2ETokenBar.ZeroHpPrompt.Confirm"),
-        callback: html => {
-          const input = html.find('input[name="initiative"]').get(0);
+        callback: element => {
+          const input = element.querySelector('input[name="initiative"]');
           const value = Number(input?.value ?? "");
           return Number.isFinite(value) ? value : null;
         },
@@ -745,18 +750,12 @@ class PF2ETokenBar {
                 documents: true,
                 rollData: doc?.actor?.getRollData?.()
               });
-              const dialog = new Dialog({
+              await ModuleDialog.prompt({
                 title: doc?.name ?? "",
                 content: enriched,
-                buttons: {
-                  chat: {
-                    label: '<i class="fas fa-comment"></i>',
-                    callback: () => ChatMessage.create({ content: enriched })
-                  }
-                }
+                label: '<i class="fas fa-comment"></i>',
+                callback: () => ChatMessage.create({ content: enriched }),
               });
-              dialog.render(true);
-              dialog.element.find('button').addClass('pf2e-effect-dialog-chat');
             } catch (err) {
               console.error("PF2ETokenBar | failed to show effect description", err);
             }
@@ -877,13 +876,11 @@ class PF2ETokenBar {
     questLogBtn.title = questLogTitle;
     questLogBtn.setAttribute("aria-label", questLogTitle);
     const updateQuestLogBtn = () => {
-      const questLogActive = game.modules.get("forien-quest-log")?.active ?? false;
-      questLogBtn.disabled = !questLogActive;
+      questLogBtn.disabled = !QuestLogIntegration.active;
     };
     updateQuestLogBtn();
     questLogBtn.addEventListener("click", () => {
-      if (!game.modules.get("forien-quest-log")?.active) return;
-      Hooks.callAll("ForienQuestLog.Open.QuestLog");
+      QuestLogIntegration.open();
     });
     controls.appendChild(questLogBtn);
 
@@ -892,26 +889,13 @@ class PF2ETokenBar {
     const pointsTrackerTitle = game.i18n.localize("PF2ETokenBar.PointsTracker");
     pointsTrackerBtn.title = pointsTrackerTitle;
     pointsTrackerBtn.setAttribute("aria-label", pointsTrackerTitle);
-    const getPointsTrackerOpener = () => {
-      if (typeof game.pf2ePointsTracker?.open === "function") {
-        return () => game.pf2ePointsTracker.open();
-      }
-      if (typeof globalThis.openResearchTracker === "function") {
-        return () => globalThis.openResearchTracker();
-      }
-      return null;
-    };
     const updatePointsTrackerBtn = () => {
-      const pointsTrackerModule = game.modules.get("pf2e-points-tracker");
-      const opener = getPointsTrackerOpener();
-      pointsTrackerBtn.disabled = !(pointsTrackerModule?.active && opener);
+      pointsTrackerBtn.disabled = !PointsTrackerIntegration.opener;
     };
     updatePointsTrackerBtn();
     pointsTrackerBtn.addEventListener("click", () => {
-      const opener = getPointsTrackerOpener();
-      if (!opener) return;
       try {
-        opener();
+        PointsTrackerIntegration.open();
       } catch (err) {
         console.error("PF2ETokenBar | failed to open PF2e Points Tracker", err);
       }
@@ -943,7 +927,7 @@ class PF2ETokenBar {
 
     const requestRollBtn = document.createElement("button");
     requestRollBtn.innerText = game.i18n.localize("PF2ETokenBar.RequestRoll");
-    requestRollBtn.addEventListener("click", () => game.pf2e.gm.checkPrompt({ actors }));
+    requestRollBtn.addEventListener("click", () => PF2eAdapter.requestCheck(actors));
 
     const encounterBtn = document.createElement("button");
     const encounterKey = activeCombat?.started ? "PF2ETokenBar.EndEncounter" : "PF2ETokenBar.StartEncounter";
@@ -952,7 +936,7 @@ class PF2ETokenBar {
       try {
         if (game.combat?.started) {
           if (game.user.isGM && game.settings.get("pf2e-token-bar", "quickLoot")) {
-            const confirmed = await Dialog.confirm({
+            const confirmed = await ModuleDialog.confirm({
               title: game.i18n.localize("PF2ETokenBar.QuickLootConfirmTitle"),
               content: `<p>${game.i18n.localize("PF2ETokenBar.QuickLootConfirmContent")}</p>`
             });
@@ -993,7 +977,7 @@ class PF2ETokenBar {
       clearEffectsBtn.innerHTML = '<i class="fas fa-broom"></i>';
       clearEffectsBtn.title = game.i18n.localize("PF2ETokenBar.ClearZeroHpEffects");
       clearEffectsBtn.addEventListener("click", async () => {
-        const confirmed = await Dialog.confirm({
+        const confirmed = await ModuleDialog.confirm({
           title: game.i18n.localize("PF2ETokenBar.ClearZeroHpEffects"),
           content: `<p>${game.i18n.localize("PF2ETokenBar.ClearZeroHpEffectsConfirm")}</p>`
         });
@@ -1178,46 +1162,26 @@ class PF2ETokenBar {
     }
   }
 
-    static _partyTokens() {
-      if (game.combat?.started) return [];
-      let actors = game.actors.party?.members || [];
-      if (game.settings.get("pf2e-token-bar", "partyOnlySelf") && !game.user.isGM) {
-        const userChar = game.user.character;
-        actors = actors.filter(a => (userChar && a.id === userChar.id) || a.isOwner);
-      }
-      this.debug(
-        `PF2ETokenBar | _partyTokens found ${actors.length} actors`,
-        actors.map(a => a.id)
-      );
-      return actors;
-    }
+  static _partyTokens() {
+    const actors = TokenProvider.partyActors();
+    this.debug(`PF2ETokenBar | _partyTokens found ${actors.length} actors`, actors.map(actor => actor.id));
+    return actors;
+  }
 
-    static _combatTokens() {
-      let combatants = Array.from(game.combat?.combatants ?? []);
-      combatants.sort((a, b) => {
-        const diff = (b.initiative ?? -Infinity) - (a.initiative ?? -Infinity);
-        if (diff !== 0) return diff;
-        const aIsPlayer = a.actor?.hasPlayerOwner ? 1 : 0;
-        const bIsPlayer = b.actor?.hasPlayerOwner ? 1 : 0;
-        return aIsPlayer - bIsPlayer;   // NPCs (0) vor PCs (1)
-      });
-      let tokens = combatants.map(c => canvas.tokens.get(c.tokenId)).filter(t => t);
-      tokens = tokens.filter(t => !t.document.hidden || game.user.isGM);
-      this.debug(
-        `PF2ETokenBar | _combatTokens found ${tokens.length} tokens`,
-        tokens.map(t => t.id)
-      );
-      return tokens;
-    }
+  static _combatTokens() {
+    const tokens = TokenProvider.combatTokens();
+    this.debug(`PF2ETokenBar | _combatTokens found ${tokens.length} tokens`, tokens.map(token => token.id));
+    return tokens;
+  }
 
   static _activePlayerTokens() {
-    const tokens = canvas.tokens.placeables.filter(t => t.actor?.hasPlayerOwner);
-    this.debug(`PF2ETokenBar | _activePlayerTokens filtered ${tokens.length} tokens`, tokens.map(t => t.actor?.id));
+    const tokens = TokenProvider.activePlayerTokens();
+    this.debug(`PF2ETokenBar | _activePlayerTokens filtered ${tokens.length} tokens`, tokens.map(token => token.actor?.id));
     return tokens;
   }
 
   static openPartyStash() {
-    const party = game.actors.party;
+    const party = PF2eAdapter.getParty();
     if (party?.sheet) {
       party.sheet.render(true, { tab: "inventory" });
     } else {
@@ -1244,7 +1208,7 @@ class PF2ETokenBar {
       return;
     }
     if (!lootActor.isOwner) {
-      ui.notifications.error("You do not have permission to modify the Loot actor.");
+      ui.notifications.error(game.i18n.localize("PF2ETokenBar.LootPermission"));
       return;
     }
 
@@ -1348,10 +1312,10 @@ class PF2ETokenBar {
       const actor = target && typeof target === "object"
         ? target
         : target === "party"
-          ? game.actors.party
+          ? PF2eAdapter.getParty()
           : game.actors.getName(target);
       if (!actor) throw new Error(game.i18n.format("PF2ETokenBar.TokenMissing", { name: target }));
-      if (!actor.isOwner) throw new Error("You do not have permission to modify this actor.");
+      if (!actor.isOwner) throw new Error(game.i18n.localize("PF2ETokenBar.ActorPermission"));
 
       if (sourceActor && sourceActor === actor) return;
 
@@ -1360,18 +1324,18 @@ class PF2ETokenBar {
       if (!isEffect && sourceActor && sourceActor !== actor) await item.delete();
     } catch (err) {
       console.error(err);
-      ui.notifications.error(err.message || "Failed to drop item.");
+      ui.notifications.error(err.message || game.i18n.localize("PF2ETokenBar.DropFailed"));
     }
   }
 
   static async awardXPDialog() {
-    await Dialog.prompt({
+    await ModuleDialog.prompt({
       title: game.i18n.localize("PF2ETokenBar.GiveXPTitle"),
       label: game.i18n.localize("PF2ETokenBar.Roll"),
       content: `<form><div class="form-group"><label>${game.i18n.localize("PF2ETokenBar.GiveXPLabel")}</label><input type="number" name="xp"/></div></form>`,
-      callback: async html => {
-        const xp = Number(html.find("input[name='xp']").val());
-        for (const actor of game.actors.party?.members ?? []) {
+      callback: async element => {
+        const xp = Number(element.querySelector("input[name='xp']")?.value);
+        for (const actor of PF2eAdapter.getPartyMembers()) {
           const curr = actor.system.details.xp.value;
           if (typeof actor.grantExperience === "function") {
             await actor.grantExperience(xp, { skipLevelUp: true });
@@ -1388,41 +1352,16 @@ class PF2ETokenBar {
   }
 
   static async executeWorkbenchMacro(macroName, ...args) {
-    if (!game.modules.get("xdy-pf2e-workbench")?.active) {
-      ui.notifications.warn(
-        game.i18n.localize("PF2ETokenBar.ShortRestDialogWorkbenchMissing")
-      );
+    if (!WorkbenchIntegration.active) {
+      ui.notifications.warn(game.i18n.localize("PF2ETokenBar.ShortRestDialogWorkbenchMissing"));
       return false;
     }
 
-    const macroCollection = game.macros;
-    const macro =
-      macroCollection?.getName?.(macroName) ??
-      macroCollection?.find(doc => doc?.name === macroName);
-    if (macro) {
-      await macro.execute(...args);
-      return true;
+    const executed = await WorkbenchIntegration.executeMacro(macroName, ...args);
+    if (!executed) {
+      ui.notifications.warn(game.i18n.format("PF2ETokenBar.ShortRestDialogWorkbenchMacroMissing", { name: macroName }));
     }
-
-    for (const pack of game.packs.filter(pack => pack.documentName === "Macro")) {
-      const index = await pack.getIndex();
-      const entry = index.find(item => item.name === macroName);
-      if (!entry) continue;
-
-      const document = await pack.getDocument(entry._id);
-      if (!document) continue;
-
-      await document.execute(...args);
-      return true;
-    }
-
-    ui.notifications.warn(
-      game.i18n.format("PF2ETokenBar.ShortRestDialogWorkbenchMacroMissing", {
-        name: macroName
-      })
-    );
-
-    return false;
+    return executed;
   }
 
   static async openTreatWoundsDialog() {
@@ -1451,23 +1390,23 @@ class PF2ETokenBar {
       </form>
     `;
 
-    await Dialog.prompt({
+    await ModuleDialog.prompt({
       title: game.i18n.localize("PF2ETokenBar.ShortRestDialogTitle"),
       label: game.i18n.localize("PF2ETokenBar.ShortRestDialogTreat"),
       content,
-      render: html => {
-        const form = html.find("form.pf2e-short-rest-dialog");
-        const healerSelect = form.find("select[name='healer']");
-        const targetsContainer = form.find(".targets");
+      onRender: element => {
+        const form = element.querySelector("form.pf2e-short-rest-dialog");
+        const healerSelect = form.querySelector("select[name='healer']");
+        const targetsContainer = form.querySelector(".targets");
 
         const updateTargets = () => {
           const existingSelections = new Map();
-          targetsContainer
-            .find("select[name^='target-']")
-            .each((_, select) => existingSelections.set(select.name, select.value));
-          targetsContainer.empty();
+          for (const select of targetsContainer.querySelectorAll("select[name^='target-']")) {
+            existingSelections.set(select.name, select.value);
+          }
+          targetsContainer.replaceChildren();
 
-          const healerId = healerSelect.val();
+          const healerId = healerSelect.value;
           const healer = actors.find(a => a.id === healerId);
           if (!healer) return;
 
@@ -1478,9 +1417,10 @@ class PF2ETokenBar {
           );
 
           if (!maxTargets) {
-            targetsContainer.append(
-              `<p class="notes">${game.i18n.localize("PF2ETokenBar.ShortRestDialogNoTargets")}</p>`
-            );
+            const note = document.createElement("p");
+            note.classList.add("notes");
+            note.textContent = game.i18n.localize("PF2ETokenBar.ShortRestDialogNoTargets");
+            targetsContainer.append(note);
             return;
           }
 
@@ -1499,19 +1439,19 @@ class PF2ETokenBar {
               </select>
             `;
             targetsContainer.append(group);
-            const select = targetsContainer.find(`select[name='${selectName}']`);
+            const select = targetsContainer.querySelector(`select[name='${selectName}']`);
             const previous = existingSelections.get(selectName);
             if (previous && availableTargets.some(actor => actor.id === previous)) {
-              select.val(previous);
+              select.value = previous;
             }
           }
         };
 
-        healerSelect.on("change", updateTargets);
+        healerSelect.addEventListener("change", updateTargets);
         updateTargets();
       },
-      callback: async html => {
-        const healerId = html.find("select[name='healer']").val();
+      callback: async element => {
+        const healerId = element.querySelector("select[name='healer']")?.value;
         const healer = actors.find(a => a.id === healerId);
         if (!healer) {
           ui.notifications.warn(
@@ -1520,11 +1460,10 @@ class PF2ETokenBar {
           return false;
         }
 
-        const selectedTargetIds = html
-          .find("select[name^='target-']")
-          .map((_, select) => select.value)
-          .get()
-          .filter(Boolean);
+        const selectedTargetIds = Array.from(
+          element.querySelectorAll("select[name^='target-']"),
+          select => select.value
+        ).filter(Boolean);
         const uniqueTargetIds = [...new Set(selectedTargetIds)];
 
         if (!uniqueTargetIds.length) {
@@ -1610,7 +1549,7 @@ class PF2ETokenBar {
               );
             }
 
-            const confirm = await Dialog.confirm({
+            const confirm = await ModuleDialog.confirm({
               title: game.i18n.localize("PF2ETokenBar.ShortRestDialogTreatAgainTitle"),
               content: `<p>${game.i18n.localize("PF2ETokenBar.ShortRestDialogTreatAgainContent")}</p>`
             });
@@ -1641,7 +1580,7 @@ class PF2ETokenBar {
   static async restAll() {
     const actors = this._partyTokens();
     if (!actors.length) return;
-    await game.pf2e.actions.restForTheNight({ actors });
+    await PF2eAdapter.restForTheNight(actors);
     this.render();
   }
 
@@ -1695,7 +1634,7 @@ class PF2ETokenBar {
   }
 
   static async healAll() {
-    const confirmed = await Dialog.confirm({
+    const confirmed = await ModuleDialog.confirm({
       title: game.i18n.localize("PF2ETokenBar.HealAll"),
       content: `<p>${game.i18n.localize("PF2ETokenBar.HealAllConfirm")}</p>`
     });
@@ -1891,9 +1830,9 @@ Hooks.once("ready", () => {
   document.addEventListener("keydown", keydownListener);
 });
 
-Hooks.once("close", () => {
+window.addEventListener("beforeunload", () => {
   if (keydownListener) document.removeEventListener("keydown", keydownListener);
-});
+}, { once: true });
 
 Hooks.on("canvasReady", () => PF2ETokenBar.render());
 Hooks.on("updateToken", () => PF2ETokenBar.render());

--- a/scripts/token-bar/token-provider.js
+++ b/scripts/token-bar/token-provider.js
@@ -1,0 +1,25 @@
+import { PF2eAdapter } from "../integrations/pf2e.js";
+
+export class TokenProvider {
+  static partyActors() {
+    if (game.combat?.started) return [];
+    const actors = PF2eAdapter.getPartyMembers();
+    if (!game.settings.get("pf2e-token-bar", "partyOnlySelf") || game.user.isGM) return actors;
+    const characterId = game.user.character?.id;
+    return actors.filter(actor => actor.id === characterId || actor.isOwner);
+  }
+
+  static combatTokens() {
+    const combatants = Array.from(game.combat?.combatants ?? []).sort((a, b) => {
+      const initiative = (b.initiative ?? -Infinity) - (a.initiative ?? -Infinity);
+      return initiative || Number(a.actor?.hasPlayerOwner) - Number(b.actor?.hasPlayerOwner);
+    });
+    return combatants
+      .map(combatant => canvas.tokens.get(combatant.tokenId))
+      .filter(token => token && (!token.document.hidden || game.user.isGM));
+  }
+
+  static activePlayerTokens() {
+    return (canvas.tokens?.placeables ?? []).filter(token => token.actor?.hasPlayerOwner);
+  }
+}

--- a/scripts/ui/dialogs.js
+++ b/scripts/ui/dialogs.js
@@ -1,0 +1,27 @@
+function dialogRoot(dialog) {
+  return dialog.element;
+}
+
+/** Native-DOM facade for Foundry V14's DialogV2. */
+export class ModuleDialog {
+  static prompt({ title, content, label, onRender, callback }) {
+    return foundry.applications.api.DialogV2.prompt({
+      window: { title },
+      content,
+      ok: {
+        label,
+        callback: (_event, _button, dialog) => callback?.(dialogRoot(dialog)),
+      },
+      render: (_event, dialog) => onRender?.(dialogRoot(dialog)),
+      rejectClose: false,
+    });
+  }
+
+  static confirm({ title, content }) {
+    return foundry.applications.api.DialogV2.confirm({
+      window: { title },
+      content,
+      rejectClose: false,
+    });
+  }
+}


### PR DESCRIPTION
### Motivation
- Bring the existing PF2e Token Bar up to Foundry V14 while keeping existing behavior and avoiding a full rewrite.
- Remove fragile V13-era patterns (global PF2e sheet classes, jQuery-style DOM access and `element[0]`) and centralize PF2e and optional-module access to make upgrades safer.

### Description
- Update the module manifest to the Foundry V14-style `compatibility` and `relationships` declaration and remove old `foundryVersion`/`systems` fields in favor of an explicit PF2e relationship in `module.json`.
- Replace legacy sheet theming code with a DOM-driven approach in `scripts/remaster-sheets.js` that avoids `ui.windows`, `ActorSheetPF2e` checks and `element[0]` fallbacks and instead uses the Application element and `querySelector`-based updates.
- Introduce a small DialogV2/native DOM facade `ModuleDialog` (`scripts/ui/dialogs.js`) and migrate brittle uses of `Dialog`, `Dialog.prompt` and `Dialog.confirm` to it, converting jQuery-style callbacks to native DOM callbacks.
- Centralize PF2e-sensitive APIs in `PF2eAdapter` (`scripts/integrations/pf2e.js`) with guards and single-warning behavior, add `WorkbenchIntegration` and optional-module adapters for quest log/points tracker, and move token/actor discovery into `TokenProvider` (`scripts/token-bar/token-provider.js`), then update `scripts/token-bar.js` to use these boundaries.
- Modernize ring menu condition handling to use the PF2e adapter and `ModuleDialog`, replace jQuery `.find/.val/.on/.empty` usage with native DOM APIs, and add localized messages for permission and drop errors.
- Minimal lifecycle and cleanup improvements, including replacing a fragile `close` hook cleanup with a `beforeunload` listener for the global keydown handler.

### Testing
- JavaScript syntax check: ran `node --check` for every `scripts/*.js` and `scripts/**/*.js`, and all files passed this check.
- JSON validation: ran `python3 -m json.tool` on `module.json`, `lang/en.json` and `lang/de.json`, and validation succeeded for all three files.
- Import-path verification: a script checked that relative ES module import targets exist and returned OK for all module imports.
- Repo checks: ran `git diff --check` and an rg-based scan for legacy patterns; results show no remaining disallowed patterns outside the new adapter/dialog modules, and no diff-check issues.

Note: these changes were validated statically in-repo (syntax, JSON, import paths and grep checks); a runtime verification in a Foundry V14 world with the current PF2e system is still recommended because `game.pf2e` APIs (for example `gm.checkPrompt`, `actions.restForTheNight`, and the ConditionManager shape) remain version-sensitive and are guarded but require live integration testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79bfe616dc8327803e98b24b477c9b)