### PR TITLE
Fix V14 compatibility: support AppV1 sheets, remove nested DialogV2 forms, guard FlatModifier, localize debug setting

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -5,6 +5,10 @@
         "Name": "PF2E Token-Leiste",
         "Hint": "Zeigt die PF2E Token-Leiste an"
       },
+      "Debug": {
+        "Name": "Debug-Protokollierung",
+        "Hint": "Gibt zusätzliche Debug-Informationen in der Konsole aus"
+      },
       "CloseCombatTracker": {
         "Name": "Standard Kampf-Tracker schließen",
         "Hint": "Verhindert, dass sich der Standard Kampf-Tracker automatisch öffnet"

--- a/lang/en.json
+++ b/lang/en.json
@@ -5,6 +5,10 @@
         "Name": "PF2E Token Bar",
         "Hint": "Show the PF2E Token Bar"
       },
+      "Debug": {
+        "Name": "Debug Logging",
+        "Hint": "Output additional debug information to the console"
+      },
       "CloseCombatTracker": {
         "Name": "Close Combat Tracker",
         "Hint": "Prevent the standard combat tracker from opening automatically"

--- a/scripts/remaster-sheets.js
+++ b/scripts/remaster-sheets.js
@@ -35,9 +35,18 @@ function applyModeToRenderedSheets(mode) {
   }
 }
 
+function getApplicationElement(application) {
+  const element = application?.element;
+
+  if (element instanceof HTMLElement) return element;
+  if (element?.[0] instanceof HTMLElement) return element[0];
+  return null;
+}
+
 function themeRenderedSheet(application) {
   const mode = game.settings.get(MODULE_ID, "remasterSheetMode");
-  applySheetMode(application.element, mode);
+  const element = getApplicationElement(application);
+  if (element) applySheetMode(element, mode);
 }
 
 Hooks.on("renderCharacterSheetPF2e", themeRenderedSheet);

--- a/scripts/ring-menu.js
+++ b/scripts/ring-menu.js
@@ -141,7 +141,7 @@ export class PF2ERingMenu {
         const options = conditions
           .map(({ slug, name }) => `<option value="${slug}">${name}</option>`)
           .join('');
-        const content = `<form><select name="condition">${options}</select></form>`;
+        const content = `<div class="pf2e-condition-dialog"><select name="condition">${options}</select></div>`;
         const slug = await ModuleDialog.prompt({
           title: game.i18n?.localize('PF2ETokenBar.Condition') || 'Condition',
           content,

--- a/scripts/rune-automation.js
+++ b/scripts/rune-automation.js
@@ -1,3 +1,5 @@
+const MODULE_ID = "pf2e-token-bar";
+
 Hooks.once("init", () => {
   game.settings.register("pf2e-token-bar", "autoFortification", {
     name: game.i18n.localize("PF2ETokenBar.Settings.AutoFortification.Name"),
@@ -68,19 +70,23 @@ Hooks.on("pf2e.prepareActorData", (actor) => {
         enabled: true,
       };
 
-      const { FlatModifier } = game.pf2e.rules;
-      const modifier = new FlatModifier({
-        slug: rune.option,
-        label: game.i18n.localize(rune.label),
-        selector: "stealth",
-        type: "item",
-        value: rune.bonus,
-        predicate: [rune.predicate, rune.option],
-        custom: true,
-      });
+      const FlatModifier = game.pf2e?.rules?.FlatModifier;
+      if (!FlatModifier) {
+        console.warn(`${MODULE_ID} | PF2e FlatModifier API unavailable`);
+      } else {
+        const modifier = new FlatModifier({
+          slug: rune.option,
+          label: game.i18n.localize(rune.label),
+          selector: "stealth",
+          type: "item",
+          value: rune.bonus,
+          predicate: [rune.predicate, rune.option],
+          custom: true,
+        });
 
-      actor.synthetics.statisticsModifiers.stealth ??= [];
-      actor.synthetics.statisticsModifiers.stealth.push(modifier);
+        actor.synthetics.statisticsModifiers.stealth ??= [];
+        actor.synthetics.statisticsModifiers.stealth.push(modifier);
+      }
     }
   }
 

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -53,8 +53,8 @@ Hooks.once("init", () => {
     onChange: () => PF2ETokenBar.render(),
   });
   game.settings.register("pf2e-token-bar", "debug", {
-    name: "Debug Logging",
-    hint: "Output additional debug information to the console",
+    name: game.i18n.localize("PF2ETokenBar.Settings.Debug.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.Debug.Hint"),
     scope: "client",
     config: true,
     type: Boolean,
@@ -1332,7 +1332,7 @@ class PF2ETokenBar {
     await ModuleDialog.prompt({
       title: game.i18n.localize("PF2ETokenBar.GiveXPTitle"),
       label: game.i18n.localize("PF2ETokenBar.Roll"),
-      content: `<form><div class="form-group"><label>${game.i18n.localize("PF2ETokenBar.GiveXPLabel")}</label><input type="number" name="xp"/></div></form>`,
+      content: `<div class="pf2e-xp-dialog"><div class="form-group"><label>${game.i18n.localize("PF2ETokenBar.GiveXPLabel")}</label><input type="number" name="xp"/></div></div>`,
       callback: async element => {
         const xp = Number(element.querySelector("input[name='xp']")?.value);
         for (const actor of PF2eAdapter.getPartyMembers()) {
@@ -1378,7 +1378,7 @@ class PF2ETokenBar {
       .join("");
 
     const content = `
-      <form class="pf2e-short-rest-dialog">
+      <div class="pf2e-short-rest-dialog">
         <div class="form-group">
           <label>${game.i18n.localize("PF2ETokenBar.ShortRestDialogHealerLabel")}</label>
           <select name="healer">
@@ -1387,7 +1387,7 @@ class PF2ETokenBar {
           </select>
         </div>
         <div class="targets"></div>
-      </form>
+      </div>
     `;
 
     await ModuleDialog.prompt({
@@ -1395,9 +1395,9 @@ class PF2ETokenBar {
       label: game.i18n.localize("PF2ETokenBar.ShortRestDialogTreat"),
       content,
       onRender: element => {
-        const form = element.querySelector("form.pf2e-short-rest-dialog");
-        const healerSelect = form.querySelector("select[name='healer']");
-        const targetsContainer = form.querySelector(".targets");
+        const container = element.querySelector(".pf2e-short-rest-dialog");
+        const healerSelect = container.querySelector("select[name='healer']");
+        const targetsContainer = container.querySelector(".targets");
 
         const updateTargets = () => {
           const existingSelections = new Map();


### PR DESCRIPTION
### Motivation
- Ensure PF2e V14 compatibility by handling both Foundry ApplicationV2 (native `HTMLElement`) and legacy AppV1 (jQuery-wrapped `element`) for sheet theming. 
- Avoid nested `<form>` elements inside `DialogV2` content because DialogV2 supplies its own form handling and nested forms break V14 behavior. 
- Prevent runtime crashes when PF2e internals like `FlatModifier` are unavailable by accessing them defensively. 
- Move visible debug-setting strings into localization files to support i18n and avoid hard-coded English UI text.

### Description
- Added a small helper `getApplicationElement(application)` and switched `themeRenderedSheet` to use it so `remaster-sheets.js` now accepts native `HTMLElement` or AppV1 `application.element[0]`, and safely ignores unknown element shapes (`scripts/remaster-sheets.js`).
- Removed nested `<form>` markup from DialogV2 content and replaced it with neutral containers, updating selectors accordingly in the ring menu condition dialog and the token-bar dialogs (XP dialog and Treat Wounds dialog) so input querying still works (`scripts/ring-menu.js`, `scripts/token-bar.js`).
- Made `FlatModifier` access defensive in `rune-automation.js` by using optional chaining (`game.pf2e?.rules?.FlatModifier`) and logging a warning instead of throwing when the API is missing, while preserving existing modifier creation when available (`scripts/rune-automation.js`).
- Localized the debug setting by switching to the keys `PF2ETokenBar.Settings.Debug.Name` and `PF2ETokenBar.Settings.Debug.Hint` and adding corresponding entries to `lang/en.json` and `lang/de.json` (`scripts/token-bar.js`, `lang/en.json`, `lang/de.json`).
- Files changed: `scripts/remaster-sheets.js`, `scripts/ring-menu.js`, `scripts/token-bar.js`, `scripts/rune-automation.js`, `lang/en.json`, `lang/de.json`.

### Testing
- Ran `node --check` on all `scripts/*.js` files and the check completed successfully for all modified files. 
- Verified JSON localization files with `node -e 'JSON.parse(...)'` and confirmed `lang/en.json`, `lang/de.json`, and `module.json` are valid JSON. 
- Searched for forbidden patterns with `rg` and confirmed no nested `<form>` markup, stale `querySelector("form...")` selectors, or jQuery calls (`$(`) remain in scripts, and no `ActorSheetPF2e` references were introduced. 
- Confirmed all relative import/export paths resolve, `git diff --check` reported no issues, and changes were committed as `Fix Foundry V14 compatibility regressions`.

Note: a live Foundry V14 / PF2e V14 runtime was not available in this environment, so tests were limited to static analysis and syntax/JSON checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79ca07a0c8832787f1e2994aa85820)