### PR TITLE
Add Encounter Turn Assistant with PF2e Action/Reaction Tracking

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -66,6 +66,34 @@
           "RemasterDark": "Dark Mode (Remaster)",
           "RemasterRed": "Dark Mode (Rot)"
         }
+      },
+      "TurnAssistant": {
+        "Enabled": {
+          "Name": "Encounter Turn Assistant aktivieren",
+          "Hint": "Zeigt Aktionsressourcen und Zughinweise für den aktiven Kampfteilnehmer."
+        },
+        "AutoActions": {
+          "Name": "Automatisches Action-Tracking aktivieren",
+          "Hint": "Verfolgt eindeutig identifizierte PF2e-Aktionsaktivitäten aus Chatnachrichten."
+        },
+        "AutoReactions": {
+          "Name": "Automatisches Reaction-Tracking aktivieren",
+          "Hint": "Verfolgt eindeutig identifizierte PF2e-Reaktionen, auch außerhalb des eigenen Zuges."
+        },
+        "ShowWarnings": {
+          "Name": "Zugwarnungen anzeigen",
+          "Hint": "Zeigt wichtige PF2e-Zustände an, ohne deren Regeln zu automatisieren."
+        },
+        "ShowHistory": {
+          "Name": "Aktionsverlauf anzeigen",
+          "Hint": "Zeigt die letzte automatische oder manuelle Ressourcenänderung."
+        },
+        "TrackingMode": {
+          "Name": "Tracking-Modus",
+          "Hint": "Konservativ bucht nur sichere Events; Automatisch auch Events mit hoher Sicherheit.",
+          "Conservative": "Konservativ",
+          "Automatic": "Automatisch"
+        }
       }
     },
     "QuickLootConfirmTitle": "Schnellbeute",
@@ -160,6 +188,20 @@
     "Confirm": "OK",
     "LootPermission": "Du hast keine Berechtigung, den Beute-Akteur zu bearbeiten.",
     "ActorPermission": "Du hast keine Berechtigung, diesen Akteur zu bearbeiten.",
-    "DropFailed": "Gegenstand konnte nicht abgelegt werden."
+    "DropFailed": "Gegenstand konnte nicht abgelegt werden.",
+    "TurnAssistant": {
+      "Turn": "ZUG",
+      "ActionsRemaining": "{count} Aktionen verbleibend",
+      "ReactionAvailable": "Reaktion verfügbar",
+      "ReactionSpent": "Reaktion verbraucht",
+      "Last": "Zuletzt: {label}",
+      "AdditionalAction": "Weitere Aktion erkannt, nachdem alle Aktionen verbraucht waren.",
+      "ManualSpend": "Aktion manuell verbraucht",
+      "ManualRestore": "Aktion manuell wiederhergestellt",
+      "SpendAction": "1 Aktion verbrauchen",
+      "RestoreAction": "1 Aktion wiederherstellen",
+      "Undo": "Rückgängig",
+      "EndTurn": "Zug beenden"
+    }
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,34 @@
           "RemasterDark": "Dark Mode (Remaster)",
           "RemasterRed": "Dark Mode (Red)"
         }
+      },
+      "TurnAssistant": {
+        "Enabled": {
+          "Name": "Enable Encounter Turn Assistant",
+          "Hint": "Show action resources and turn notes for the active combatant."
+        },
+        "AutoActions": {
+          "Name": "Enable Automatic Action Tracking",
+          "Hint": "Track explicitly identified PF2e action activities from chat messages."
+        },
+        "AutoReactions": {
+          "Name": "Enable Automatic Reaction Tracking",
+          "Hint": "Track explicitly identified PF2e reactions, including outside the actor’s turn."
+        },
+        "ShowWarnings": {
+          "Name": "Show Turn Warnings",
+          "Hint": "Show important PF2e conditions without automating their rules."
+        },
+        "ShowHistory": {
+          "Name": "Show Action History",
+          "Hint": "Show the most recent tracked or manual resource change."
+        },
+        "TrackingMode": {
+          "Name": "Tracking Mode",
+          "Hint": "Conservative tracks only certain events; Automatic also tracks high-confidence events.",
+          "Conservative": "Conservative",
+          "Automatic": "Automatic"
+        }
       }
     },
     "QuickLootConfirmTitle": "Quick Loot",
@@ -160,6 +188,20 @@
     "Confirm": "OK",
     "LootPermission": "You do not have permission to modify the Loot actor.",
     "ActorPermission": "You do not have permission to modify this actor.",
-    "DropFailed": "Failed to drop item."
+    "DropFailed": "Failed to drop item.",
+    "TurnAssistant": {
+      "Turn": "TURN",
+      "ActionsRemaining": "{count} actions remaining",
+      "ReactionAvailable": "Reaction available",
+      "ReactionSpent": "Reaction spent",
+      "Last": "Last: {label}",
+      "AdditionalAction": "Additional action detected after all actions were spent.",
+      "ManualSpend": "Manual action spent",
+      "ManualRestore": "Manual action restored",
+      "SpendAction": "Spend 1 action",
+      "RestoreAction": "Restore 1 action",
+      "Undo": "Undo",
+      "EndTurn": "End Turn"
+    }
   }
 }

--- a/scripts/encounter/turn-assistant/action-state.js
+++ b/scripts/encounter/turn-assistant/action-state.js
@@ -1,0 +1,27 @@
+const MODULE_ID = "pf2e-token-bar";
+const FLAG = "turnAssistant";
+
+export class ActionState {
+  static async read(combatant) {
+    return combatant?.getFlag(MODULE_ID, FLAG) ?? null;
+  }
+
+  static async write(combatant, state) {
+    if (!combatant || !state) return null;
+    await combatant.setFlag(MODULE_ID, FLAG, state);
+    return state;
+  }
+
+  static create(combatant, maximum = 3, previous = null) {
+    return {
+      combatId: combatant.combat?.id ?? game.combat?.id,
+      combatantId: combatant.id,
+      actorId: combatant.actorId,
+      turn: `${combatant.combat?.round ?? 0}:${combatant.combat?.turn ?? 0}`,
+      actions: { max: maximum, remaining: maximum },
+      reaction: { available: true },
+      history: [], pending: null, overSpent: false,
+      processed: previous?.processed?.slice(-100) ?? [],
+    };
+  }
+}

--- a/scripts/encounter/turn-assistant/action-tracker.js
+++ b/scripts/encounter/turn-assistant/action-tracker.js
@@ -1,0 +1,89 @@
+import { PF2eAdapter } from "../../integrations/pf2e.js";
+import { ActionState } from "./action-state.js";
+import { ActivityDetector } from "./detectors/activity-detector.js";
+import { StrikeDetector } from "./detectors/strike-detector.js";
+
+const MODULE_ID = "pf2e-token-bar";
+
+export class ActionTracker {
+  static detectors = [ActivityDetector, StrikeDetector];
+  static onChange = () => {};
+
+  static isAuthority(message = null) {
+    const gm = game.users?.filter(user => user.active && user.isGM).sort((a, b) => a.id.localeCompare(b.id))[0];
+    return gm ? game.user.id === gm.id : message?.user?.id === game.user.id;
+  }
+
+  static findCombatant(actorOrId) {
+    const id = actorOrId?.id ?? actorOrId;
+    return game.combat?.combatants.find(c => c.actorId === id) ?? null;
+  }
+
+  static async startTurn(combatant) {
+    if (!combatant || !this.isAuthority()) return;
+    const old = await ActionState.read(combatant);
+    const key = `${combatant.combat?.round ?? 0}:${combatant.combat?.turn ?? 0}`;
+    if (old?.turn === key && old?.combatId === combatant.combat?.id) return;
+    const maximum = PF2eAdapter.getPreparedActionCount(combatant.actor) ?? 3;
+    await ActionState.write(combatant, ActionState.create(combatant, maximum, old));
+  }
+
+  static async record(combatant, event) {
+    if (!combatant || !event) return false;
+    const state = await ActionState.read(combatant) ?? ActionState.create(combatant, PF2eAdapter.getPreparedActionCount(combatant.actor) ?? 3);
+    if (event.identity && state.processed.includes(event.identity)) return false;
+    const before = { actions: state.actions.remaining, reaction: state.reaction.available };
+    if (event.resource === "action") {
+      const spend = Math.max(0, Number(event.cost) || 0);
+      state.overSpent ||= spend > state.actions.remaining;
+      state.actions.remaining = Math.max(0, state.actions.remaining - spend);
+    } else if (event.resource === "reaction") state.reaction.available = false;
+    state.history.push({ id: event.identity ?? foundry.utils.randomID(), label: event.label, resource: event.resource, cost: event.cost, automatic: event.automatic ?? false, timestamp: Date.now(), before });
+    if (event.identity) state.processed.push(event.identity);
+    state.processed = state.processed.slice(-100);
+    await ActionState.write(combatant, state);
+    this.onChange();
+    return true;
+  }
+
+  static async processMessage(message) {
+    if (!game.settings.get(MODULE_ID, "turnAssistant") || !this.isAuthority(message)) return;
+    for (const detector of this.detectors) {
+      const event = detector.detect(message);
+      if (!event) continue;
+      const allowed = event.confidence === "certain" || (event.confidence === "high" && game.settings.get(MODULE_ID, "trackingMode") === "automatic");
+      if (!allowed) { this.debug("Action detection skipped: insufficient confidence", event); return; }
+      if (event.resource === "reaction" && !game.settings.get(MODULE_ID, "autoReactions")) return;
+      if (["action", "free"].includes(event.resource) && !game.settings.get(MODULE_ID, "autoActions")) return;
+      const combatant = this.findCombatant(event.actorId);
+      if (combatant) {
+        this.debug("Detected action", { label: event.label, actorId: event.actorId, cost: event.cost, confidence: event.confidence, messageId: message.id });
+        await this.record(combatant, { ...event, automatic: true });
+      }
+      return;
+    }
+  }
+
+  static async adjust(combatant, delta) {
+    if (delta < 0) return this.record(combatant, { resource: "action", cost: Math.abs(delta), label: game.i18n.localize("PF2ETokenBar.TurnAssistant.ManualSpend") });
+    const state = await ActionState.read(combatant);
+    if (!state) return false;
+    const before = { actions: state.actions.remaining, reaction: state.reaction.available };
+    state.actions.remaining = Math.min(state.actions.max, state.actions.remaining + delta);
+    state.history.push({ id: foundry.utils.randomID(), label: game.i18n.localize("PF2ETokenBar.TurnAssistant.ManualRestore"), resource: "refund", cost: delta, automatic: false, timestamp: Date.now(), before });
+    await ActionState.write(combatant, state); this.onChange(); return true;
+  }
+
+  static async undo(combatant) {
+    const state = await ActionState.read(combatant); const entry = state?.history.pop();
+    if (!entry) return false;
+    state.actions.remaining = Math.min(state.actions.max, entry.before.actions);
+    state.reaction.available = entry.before.reaction;
+    state.overSpent = false;
+    await ActionState.write(combatant, state); this.onChange(); return true;
+  }
+
+  static debug(label, data) {
+    if (game.settings.get(MODULE_ID, "debug")) console.debug(`${MODULE_ID} | ${label}`, data);
+  }
+}

--- a/scripts/encounter/turn-assistant/detectors/activity-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/activity-detector.js
@@ -1,0 +1,22 @@
+import { PF2eAdapter } from "../../../integrations/pf2e.js";
+
+/** Detect only messages carrying both a PF2e roll context and an item with an explicit cost. */
+export class ActivityDetector {
+  static detect(message) {
+    const context = PF2eAdapter.getMessageContext(message);
+    const actor = PF2eAdapter.resolveMessageActor(message);
+    const item = PF2eAdapter.resolveMessageItem(message);
+    const cost = PF2eAdapter.getActionCost(item);
+    if (!context || !actor || !item || !cost) return null;
+
+    const type = String(context.type ?? "");
+    if (type.includes("damage") || type.includes("healing")) return null;
+    const executed = type.includes("roll") || type === "spell-cast" || type === "self-effect" || context.outcome != null;
+    if (!executed) return null;
+    return {
+      actorId: actor.id, resource: cost.type, cost: cost.value,
+      label: item.name ?? message.flavor ?? "PF2e Activity",
+      confidence: "certain", identity: `message:${message.id}`,
+    };
+  }
+}

--- a/scripts/encounter/turn-assistant/detectors/strike-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/strike-detector.js
@@ -1,0 +1,12 @@
+import { PF2eAdapter } from "../../../integrations/pf2e.js";
+
+export class StrikeDetector {
+  static detect(message) {
+    const context = PF2eAdapter.getMessageContext(message);
+    if (context?.type !== "attack-roll") return null;
+    const actor = PF2eAdapter.resolveMessageActor(message);
+    const item = PF2eAdapter.resolveMessageItem(message);
+    if (!actor || !item?.isOfType?.("weapon", "melee")) return null;
+    return { actorId: actor.id, resource: "action", cost: 1, label: message.item?.name ?? "Strike", confidence: "high", identity: `message:${message.id}` };
+  }
+}

--- a/scripts/encounter/turn-assistant/turn-assistant.js
+++ b/scripts/encounter/turn-assistant/turn-assistant.js
@@ -1,0 +1,72 @@
+import { PF2eAdapter } from "../../integrations/pf2e.js";
+import { ActionState } from "./action-state.js";
+import { ActionTracker } from "./action-tracker.js";
+import { TurnWarnings } from "./turn-warnings.js";
+
+const MODULE_ID = "pf2e-token-bar";
+
+function glyph(type, value = 1) {
+  const span = document.createElement("span");
+  span.className = "action-glyph";
+  span.textContent = PF2eAdapter.getActionGlyph(type, value);
+  return span;
+}
+
+export class TurnAssistant {
+  static startTurn(combatant) {
+    return ActionTracker.startTurn(combatant);
+  }
+
+  static async render(combatant) {
+    if (!game.settings.get(MODULE_ID, "turnAssistant")) return null;
+    const state = await ActionState.read(combatant);
+    if (!state) return null;
+    const root = document.createElement("section"); root.className = "pf2e-turn-assistant";
+    const title = document.createElement("strong"); title.textContent = game.i18n.localize("PF2ETokenBar.TurnAssistant.Turn"); root.append(title);
+
+    const resources = document.createElement("div"); resources.className = "pf2e-turn-resources";
+    const actions = document.createElement("span"); actions.className = "pf2e-turn-actions";
+    for (let i = 0; i < state.actions.remaining; i++) actions.append(glyph("action"));
+    actions.title = game.i18n.format("PF2ETokenBar.TurnAssistant.ActionsRemaining", { count: state.actions.remaining }); resources.append(actions);
+    const reaction = glyph("reaction"); reaction.classList.toggle("spent", !state.reaction.available); reaction.title = game.i18n.localize(`PF2ETokenBar.TurnAssistant.Reaction${state.reaction.available ? "Available" : "Spent"}`); resources.append(reaction); root.append(resources);
+
+    const last = state.history.at(-1);
+    if (last && game.settings.get(MODULE_ID, "showActionHistory")) {
+      const history = document.createElement("div"); history.className = "pf2e-turn-last";
+      history.textContent = game.i18n.format("PF2ETokenBar.TurnAssistant.Last", { label: last.label }); root.append(history);
+    }
+    if (state.overSpent) { const warning = document.createElement("div"); warning.className = "pf2e-turn-warning"; warning.textContent = game.i18n.localize("PF2ETokenBar.TurnAssistant.AdditionalAction"); root.append(warning); }
+    const warnings = game.settings.get(MODULE_ID, "showTurnWarnings") ? TurnWarnings.get(combatant.actor) : [];
+    if (warnings.length) { const notes = document.createElement("ul"); notes.className = "pf2e-turn-warnings"; for (const item of warnings) { const li = document.createElement("li"); li.textContent = item.label; notes.append(li); } root.append(notes); }
+
+    const controls = document.createElement("div"); controls.className = "pf2e-turn-controls";
+    const button = (label, handler) => { const element = document.createElement("button"); element.type = "button"; element.title = label; element.setAttribute("aria-label", label); element.addEventListener("click", handler); controls.append(element); return element; };
+    button(game.i18n.localize("PF2ETokenBar.TurnAssistant.SpendAction"), () => ActionTracker.adjust(combatant, -1)).append(glyph("action"), document.createTextNode("−"));
+    button(game.i18n.localize("PF2ETokenBar.TurnAssistant.RestoreAction"), () => ActionTracker.adjust(combatant, 1)).append(glyph("action"), document.createTextNode("+"));
+    const undo = button(game.i18n.localize("PF2ETokenBar.TurnAssistant.Undo"), () => ActionTracker.undo(combatant)); undo.innerHTML = '<i class="fas fa-undo"></i>'; undo.disabled = !last;
+    const end = button(game.i18n.localize("PF2ETokenBar.TurnAssistant.EndTurn"), () => game.combat?.nextTurn()); end.innerHTML = '<i class="fas fa-forward-step"></i>'; root.append(controls);
+    return root;
+  }
+
+  static registerHooks(render) {
+    ActionTracker.onChange = render;
+    Hooks.on("createChatMessage", message => ActionTracker.processMessage(message));
+    Hooks.on("updateCombat", async combat => { if (combat.id === game.combat?.id && combat.started) await ActionTracker.startTurn(combat.combatant); });
+    Hooks.on("combatStart", combat => ActionTracker.startTurn(combat.combatant));
+    Hooks.on("deleteCombatant", combatant => { if (combatant.id === game.combat?.combatant?.id) render(); });
+    Hooks.on("deleteCombat", render);
+  }
+
+  static exposeApi() {
+    const resolve = actor => ActionTracker.findCombatant(actor);
+    game.pf2eTokenBar ??= {};
+    game.pf2eTokenBar.actions = {
+      consume: (actor, cost = 1, label = "Macro") => ActionTracker.record(resolve(actor), { resource: "action", cost, label }),
+      refund: (actor, cost = 1) => ActionTracker.adjust(resolve(actor), Math.abs(cost)),
+      consumeReaction: (actor, label = "Macro") => ActionTracker.record(resolve(actor), { resource: "reaction", cost: 1, label }),
+      restoreReaction: async actor => { const combatant = resolve(actor); const state = await ActionState.read(combatant); if (!state) return false; state.reaction.available = true; return ActionState.write(combatant, state); },
+      record: ({ actor, type, cost = 0, label = "Macro" }) => ActionTracker.record(resolve(actor), { resource: type, cost, label }),
+      undo: actor => ActionTracker.undo(resolve(actor)),
+    };
+  }
+}

--- a/scripts/encounter/turn-assistant/turn-warnings.js
+++ b/scripts/encounter/turn-assistant/turn-warnings.js
@@ -1,0 +1,12 @@
+export class TurnWarnings {
+  static get(actor) {
+    const conditions = Array.from(actor?.conditions?.active ?? []);
+    return conditions.flatMap(condition => {
+      const slug = condition.slug ?? condition.system?.slug;
+      if (!slug || !["persistent-damage", "dying", "stunned", "slowed", "frightened", "wounded"].includes(slug)) return [];
+      const value = condition.badge?.value ?? condition.system?.badge?.value ?? condition.value;
+      const suffix = value == null ? "" : ` ${value}`;
+      return [{ slug, label: `${condition.name}${suffix}`, critical: ["persistent-damage", "dying"].includes(slug) }];
+    });
+  }
+}

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -9,6 +9,44 @@ function warnOnce(api) {
 
 /** The deliberately small boundary around PF2e's public, version-sensitive APIs. */
 export class PF2eAdapter {
+  static ACTION_GLYPHS = Object.freeze({ action: "1", action2: "2", action3: "3", reaction: "R", free: "F" });
+
+  static getActionGlyph(type = "action", value = 1) {
+    if (type === "reaction" || type === "free") return this.ACTION_GLYPHS[type];
+    return this.ACTION_GLYPHS[`action${value}`] ?? this.ACTION_GLYPHS.action;
+  }
+
+  static getActionCost(item) {
+    const cost = item?.actionCost ?? item?.system?.actionType;
+    if (!cost && item?.isOfType?.("spell")) {
+      const glyph = item.actionGlyph;
+      if (["1", "2", "3"].includes(glyph)) return { type: "action", value: Number(glyph) };
+      if (glyph === "R") return { type: "reaction", value: 1 };
+      if (glyph === "F") return { type: "free", value: 0 };
+    }
+    if (!cost || !["action", "reaction", "free"].includes(cost.type)) return null;
+    const value = cost.type === "action" ? Number(cost.value) : cost.type === "reaction" ? 1 : 0;
+    if (cost.type === "action" && ![1, 2, 3].includes(value)) return null;
+    return { type: cost.type, value };
+  }
+
+  static resolveMessageActor(message) {
+    return message?.actor ?? game.actors?.get(message?.speaker?.actor) ?? null;
+  }
+
+  static resolveMessageItem(message) {
+    return message?.item ?? null;
+  }
+
+  static getMessageContext(message) {
+    return message?.flags?.pf2e?.context ?? null;
+  }
+
+  static getPreparedActionCount(actor) {
+    const prepared = actor?.system?.attributes?.actions;
+    const value = Number(prepared?.value ?? prepared?.max);
+    return Number.isInteger(value) && value >= 0 && value <= 3 ? value : null;
+  }
   static getParty() {
     return game.actors?.party ?? null;
   }

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -4,6 +4,7 @@ import { WorkbenchIntegration } from "./integrations/workbench.js";
 import { PointsTrackerIntegration, QuestLogIntegration } from "./integrations/optional-modules.js";
 import { TokenProvider } from "./token-bar/token-provider.js";
 import { ModuleDialog } from "./ui/dialogs.js";
+import { TurnAssistant } from "./encounter/turn-assistant/turn-assistant.js";
 
 Hooks.once("init", () => {
   game.settings.register("pf2e-token-bar", "position", {
@@ -120,6 +121,15 @@ Hooks.once("init", () => {
     default: true,
     onChange: () => PF2ETokenBar.render(),
   });
+  const assistantSettings = [
+    ["turnAssistant", "Enabled", true, "world"], ["autoActions", "AutoActions", true, "world"],
+    ["autoReactions", "AutoReactions", true, "world"], ["showTurnWarnings", "ShowWarnings", true, "client"],
+    ["showActionHistory", "ShowHistory", true, "client"],
+  ];
+  for (const [key, label, defaultValue, scope] of assistantSettings) game.settings.register("pf2e-token-bar", key, {
+    name: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Name`), hint: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Hint`), scope, config: true, type: Boolean, default: defaultValue, onChange: () => PF2ETokenBar.render(),
+  });
+  game.settings.register("pf2e-token-bar", "trackingMode", { name: game.i18n.localize("PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Name"), hint: game.i18n.localize("PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Hint"), scope: "world", config: true, type: String, choices: { conservative: "PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Conservative", automatic: "PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Automatic" }, default: "conservative" });
 });
 
 class PF2ETokenBar {
@@ -482,7 +492,7 @@ class PF2ETokenBar {
       }
     }
 
-    tokens.forEach(token => {
+    tokens.forEach(async token => {
       const actor = token.actor;
       const wrapper = document.createElement("div");
       wrapper.classList.add("pf2e-token-wrapper");
@@ -823,6 +833,11 @@ class PF2ETokenBar {
         effectBar.appendChild(effectWrapper);
       }
       wrapper.appendChild(effectBar);
+
+      if (combatant?.id === activeCombat?.combatant?.id) {
+        const assistant = await TurnAssistant.render(combatant);
+        if (assistant && wrapper.isConnected) wrapper.appendChild(assistant);
+      }
 
       tokenContainer.appendChild(wrapper);
     });
@@ -1805,6 +1820,9 @@ globalThis.PF2ETokenBar = PF2ETokenBar;
 let keydownListener;
 
 Hooks.once("ready", () => {
+  TurnAssistant.exposeApi();
+  TurnAssistant.registerHooks(() => PF2ETokenBar.render());
+  if (game.combat?.started) TurnAssistant.startTurn(game.combat.combatant);
   game.socket.on("module.pf2e-token-bar", data => {
     if (data.action === "openLoot" && data.actorId) {
       const actor = game.actors.get(data.actorId);

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -449,3 +449,24 @@
   justify-content:center;
   margin-top:4px;
 }
+
+/* Encounter Turn Assistant: PF2e supplies the action-glyph font and glyph meanings. */
+#pf2e-token-bar .pf2e-turn-assistant {
+  width: 132px;
+  margin-top: 5px;
+  padding: 5px;
+  color: var(--color-text-light-highlight, #fff);
+  background: rgba(0, 0, 0, 0.72);
+  border: 1px solid var(--color-border-light-tertiary, #777);
+  border-radius: 4px;
+  font-size: 11px;
+}
+#pf2e-token-bar .pf2e-turn-resources,
+#pf2e-token-bar .pf2e-turn-controls { display: flex; gap: 4px; align-items: center; margin-top: 3px; }
+#pf2e-token-bar .pf2e-turn-actions { display: flex; gap: 1px; min-width: 54px; }
+#pf2e-token-bar .action-glyph { font-size: 1.35rem; line-height: 1; }
+#pf2e-token-bar .action-glyph.spent { opacity: .3; filter: grayscale(1); }
+#pf2e-token-bar .pf2e-turn-controls button { min-width: 26px; height: 24px; padding: 2px 4px; }
+#pf2e-token-bar .pf2e-turn-controls button .action-glyph { font-size: 1rem; }
+#pf2e-token-bar .pf2e-turn-last { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 3px; }
+#pf2e-token-bar .pf2e-turn-warning, #pf2e-token-bar .pf2e-turn-warnings { color: #ffb347; margin: 3px 0 0; padding-left: 14px; }


### PR DESCRIPTION
### Motivation

- Provide an in-bar Turn Assistant to support the active combatant with PF2e V14 native action-economy feedback and safe automatic tracking. 
- Keep the existing Token Bar UI and behavior, add modular logic for turn-state, detectors and history without reimplementing PF2e rules.
- Use PF2e-provided data and glyphs where possible and make automatic bookings only when confidence is sufficient and undoable.

### Description

- Added a modular turn state and persistence layer using a Combatant flag via `scripts/encounter/turn-assistant/action-state.js` to store `actions`, `reaction`, `history`, `processed` identities and overspend flags. 
- Implemented `ActionTracker` and small detectors in `scripts/encounter/turn-assistant/` to safely detect and deduplicate PF2e activities and strikes, perform authoritative booking rules (single active-GM authority) and provide `record`/`adjust`/`undo` operations; detection respects `certain/high/low` confidence and settings. 
- Extended `scripts/integrations/pf2e.js` with helpers to read PF2e `actionCost`/`actionGlyph`, message context and actor/item resolution and to render only PF2e-native glyphs (`action-glyph` with `1/2/3/R/F`). 
- Added UI integration (`turn-assistant.js`) that renders native PF2e glyphs in the Token Bar for the active combatant and provides manual `−`/`+`, `Undo`, `End Turn`, a compact history line, overspend warnings and non-automated Turn Warnings (persistent damage, dying, stunned, slowed, frightened, wounded). 
- Exposed a defensive public API at `game.pf2eTokenBar.actions` for macros/third-party modules and added settings for enabling the assistant, auto-actions, auto-reactions, show warnings/history and `trackingMode` (`conservative` default). 
- Added English and German localization strings and compact CSS to style the assistant while relying on PF2e’s action-glyph font and classes; no custom glyphs or SVGs introduced. 

### Testing

- Unit-like lifecycle smoke test via `node /tmp/test-turn-assistant.mjs` that covers turn initialization, consume, deduplication, undo (action and reaction), and overspend clamping was executed and passed. 
- Static checks were run: `node --check` across new JS files and `python3 -m json.tool` for `module.json`, `lang/en.json`, and `lang/de.json`, all completed successfully. 
- Repository sanity checks including `git diff --check` passed and no obvious syntax or localization JSON errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d97ad9888327a0885e805f390b2e)