### PR TITLE
Fix Turn Assistant rendering and add authority-routed action mutations

### DIFF
--- a/scripts/encounter/turn-assistant/action-tracker.js
+++ b/scripts/encounter/turn-assistant/action-tracker.js
@@ -4,14 +4,23 @@ import { ActivityDetector } from "./detectors/activity-detector.js";
 import { StrikeDetector } from "./detectors/strike-detector.js";
 
 const MODULE_ID = "pf2e-token-bar";
+const SOCKET_CHANNEL = `module.${MODULE_ID}`;
+const MUTATION_TYPE = "action-tracker-mutation";
+const RESOURCES = new Set(["action", "reaction", "free"]);
 
 export class ActionTracker {
   static detectors = [ActivityDetector, StrikeDetector];
   static onChange = () => {};
+  static socketRegistered = false;
+  static handledRequests = new Set();
+
+  static getAuthorityUser() {
+    return game.users?.filter(user => user.active && user.isGM).sort((a, b) => a.id.localeCompare(b.id))[0] ?? null;
+  }
 
   static isAuthority(message = null) {
-    const gm = game.users?.filter(user => user.active && user.isGM).sort((a, b) => a.id.localeCompare(b.id))[0];
-    return gm ? game.user.id === gm.id : message?.user?.id === game.user.id;
+    const authority = this.getAuthorityUser();
+    return authority ? game.user.id === authority.id : message?.user?.id === game.user.id;
   }
 
   static findCombatant(actorOrId) {
@@ -19,18 +28,120 @@ export class ActionTracker {
     return game.combat?.combatants.find(c => c.actorId === id) ?? null;
   }
 
+  static getCombatant(combatantId) {
+    return game.combat?.combatants.get?.(combatantId)
+      ?? game.combat?.combatants.find?.(combatant => combatant.id === combatantId)
+      ?? null;
+  }
+
+  static registerSocket() {
+    if (this.socketRegistered) return;
+    game.socket.on(SOCKET_CHANNEL, request => this.handleSocketRequest(request));
+    this.socketRegistered = true;
+  }
+
+  static async requestMutation(operation, combatant, payload = {}) {
+    if (!combatant) return false;
+    const requestId = foundry.utils.randomID();
+    const request = {
+      type: MUTATION_TYPE,
+      requestId,
+      senderId: game.user.id,
+      operation,
+      combatantId: combatant.id,
+      payload: { ...payload, identity: payload.identity ?? `manual:${requestId}` },
+    };
+    if (this.isAuthority()) return this.validateRequest(request) ? this.dispatchMutation(combatant, request) : false;
+    if (!this.getAuthorityUser()) {
+      console.warn(`${MODULE_ID} | Cannot mutate action state without an active GM`);
+      return false;
+    }
+    game.socket.emit(SOCKET_CHANNEL, request);
+    return true;
+  }
+
+  static async handleSocketRequest(request) {
+    if (request?.type !== MUTATION_TYPE || !this.isAuthority()) return;
+    if (!this.validateRequest(request) || this.handledRequests.has(request.requestId)) return;
+    const combatant = this.getCombatant(request.combatantId);
+    this.handledRequests.add(request.requestId);
+    if (this.handledRequests.size > 100) this.handledRequests.delete(this.handledRequests.values().next().value);
+    await this.dispatchMutation(combatant, request);
+  }
+
+  static validateRequest(request) {
+    const sender = game.users?.get?.(request?.senderId);
+    const combatant = this.getCombatant(request?.combatantId);
+    const actor = combatant?.actor;
+    if (!sender || !combatant || !actor || typeof request.requestId !== "string" || !request.requestId) return false;
+    if (!sender.isGM && !actor.testUserPermission?.(sender, "OWNER")) return false;
+    const payload = request.payload;
+    if (!payload || typeof payload !== "object") return false;
+    switch (request.operation) {
+      case "adjust": return Number.isFinite(payload.amount) && payload.amount !== 0;
+      case "consume":
+      case "refund": return Number.isFinite(payload.cost) && payload.cost >= 0 && (payload.label == null || typeof payload.label === "string");
+      case "consumeReaction": return payload.label == null || typeof payload.label === "string";
+      case "restoreReaction":
+      case "undo": return true;
+      case "record": return RESOURCES.has(payload.resource) && Number.isFinite(payload.cost) && payload.cost >= 0 && typeof payload.label === "string";
+      default: return false;
+    }
+  }
+
+  static dispatchMutation(combatant, request) {
+    const { operation, payload } = request;
+    switch (operation) {
+      case "adjust": return this.adjustLocal(combatant, payload.amount, payload.identity);
+      case "consume": return this.recordLocal(combatant, { resource: "action", cost: payload.cost, label: payload.label ?? "Macro", identity: payload.identity });
+      case "refund": return this.adjustLocal(combatant, Math.abs(payload.cost), payload.identity);
+      case "consumeReaction": return this.recordLocal(combatant, { resource: "reaction", cost: 1, label: payload.label ?? "Macro", identity: payload.identity });
+      case "restoreReaction": return this.restoreReactionLocal(combatant, payload.identity);
+      case "undo": return this.undoLocal(combatant);
+      case "record": return this.recordLocal(combatant, { resource: payload.resource, cost: payload.cost, label: payload.label, identity: payload.identity });
+      default: return false;
+    }
+  }
+
   static async startTurn(combatant) {
     if (!combatant || !this.isAuthority()) return;
     const old = await ActionState.read(combatant);
     const key = `${combatant.combat?.round ?? 0}:${combatant.combat?.turn ?? 0}`;
     if (old?.turn === key && old?.combatId === combatant.combat?.id) return;
-    const maximum = PF2eAdapter.getPreparedActionCount(combatant.actor) ?? 3;
-    await ActionState.write(combatant, ActionState.create(combatant, maximum, old));
+    await ActionState.write(combatant, ActionState.create(combatant, PF2eAdapter.getDefaultActionCount(), old));
   }
 
-  static async record(combatant, event) {
+  static record(combatant, event) {
+    return this.requestMutation("record", combatant, event);
+  }
+
+  static consume(combatant, cost = 1, label = "Macro") {
+    return this.requestMutation("consume", combatant, { cost: Number(cost), label });
+  }
+
+  static refund(combatant, cost = 1) {
+    return this.requestMutation("refund", combatant, { cost: Number(cost) });
+  }
+
+  static consumeReaction(combatant, label = "Macro") {
+    return this.requestMutation("consumeReaction", combatant, { label });
+  }
+
+  static restoreReaction(combatant) {
+    return this.requestMutation("restoreReaction", combatant);
+  }
+
+  static adjust(combatant, delta) {
+    return this.requestMutation("adjust", combatant, { amount: Number(delta) });
+  }
+
+  static undo(combatant) {
+    return this.requestMutation("undo", combatant);
+  }
+
+  static async recordLocal(combatant, event) {
     if (!combatant || !event) return false;
-    const state = await ActionState.read(combatant) ?? ActionState.create(combatant, PF2eAdapter.getPreparedActionCount(combatant.actor) ?? 3);
+    const state = await ActionState.read(combatant) ?? ActionState.create(combatant, PF2eAdapter.getDefaultActionCount());
     if (event.identity && state.processed.includes(event.identity)) return false;
     const before = { actions: state.actions.remaining, reaction: state.reaction.available };
     if (event.resource === "action") {
@@ -58,23 +169,36 @@ export class ActionTracker {
       const combatant = this.findCombatant(event.actorId);
       if (combatant) {
         this.debug("Detected action", { label: event.label, actorId: event.actorId, cost: event.cost, confidence: event.confidence, messageId: message.id });
-        await this.record(combatant, { ...event, automatic: true });
+        await this.recordLocal(combatant, { ...event, automatic: true });
       }
       return;
     }
   }
 
-  static async adjust(combatant, delta) {
-    if (delta < 0) return this.record(combatant, { resource: "action", cost: Math.abs(delta), label: game.i18n.localize("PF2ETokenBar.TurnAssistant.ManualSpend") });
+  static async adjustLocal(combatant, delta, identity) {
+    if (delta < 0) return this.recordLocal(combatant, { resource: "action", cost: Math.abs(delta), label: game.i18n.localize("PF2ETokenBar.TurnAssistant.ManualSpend"), identity });
     const state = await ActionState.read(combatant);
-    if (!state) return false;
+    if (!state || (identity && state.processed.includes(identity))) return false;
     const before = { actions: state.actions.remaining, reaction: state.reaction.available };
     state.actions.remaining = Math.min(state.actions.max, state.actions.remaining + delta);
-    state.history.push({ id: foundry.utils.randomID(), label: game.i18n.localize("PF2ETokenBar.TurnAssistant.ManualRestore"), resource: "refund", cost: delta, automatic: false, timestamp: Date.now(), before });
+    state.history.push({ id: identity ?? foundry.utils.randomID(), label: game.i18n.localize("PF2ETokenBar.TurnAssistant.ManualRestore"), resource: "refund", cost: delta, automatic: false, timestamp: Date.now(), before });
+    if (identity) state.processed.push(identity);
+    state.processed = state.processed.slice(-100);
     await ActionState.write(combatant, state); this.onChange(); return true;
   }
 
-  static async undo(combatant) {
+  static async restoreReactionLocal(combatant, identity) {
+    const state = await ActionState.read(combatant);
+    if (!state || (identity && state.processed.includes(identity))) return false;
+    const before = { actions: state.actions.remaining, reaction: state.reaction.available };
+    state.reaction.available = true;
+    state.history.push({ id: identity ?? foundry.utils.randomID(), label: "Restore Reaction", resource: "reaction-refund", cost: 0, automatic: false, timestamp: Date.now(), before });
+    if (identity) state.processed.push(identity);
+    state.processed = state.processed.slice(-100);
+    await ActionState.write(combatant, state); this.onChange(); return true;
+  }
+
+  static async undoLocal(combatant) {
     const state = await ActionState.read(combatant); const entry = state?.history.pop();
     if (!entry) return false;
     state.actions.remaining = Math.min(state.actions.max, entry.before.actions);

--- a/scripts/encounter/turn-assistant/detectors/strike-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/strike-detector.js
@@ -7,6 +7,7 @@ export class StrikeDetector {
     const actor = PF2eAdapter.resolveMessageActor(message);
     const item = PF2eAdapter.resolveMessageItem(message);
     if (!actor || !item?.isOfType?.("weapon", "melee")) return null;
-    return { actorId: actor.id, resource: "action", cost: 1, label: message.item?.name ?? "Strike", confidence: "high", identity: `message:${message.id}` };
+    // PF2e v14 creates this exact context for a completed Strike check; damage uses a different context type.
+    return { actorId: actor.id, resource: "action", cost: 1, label: message.item?.name ?? "Strike", confidence: "certain", identity: `message:${message.id}` };
   }
 }

--- a/scripts/encounter/turn-assistant/turn-assistant.js
+++ b/scripts/encounter/turn-assistant/turn-assistant.js
@@ -50,6 +50,7 @@ export class TurnAssistant {
 
   static registerHooks(render) {
     ActionTracker.onChange = render;
+    ActionTracker.registerSocket();
     Hooks.on("createChatMessage", message => ActionTracker.processMessage(message));
     Hooks.on("updateCombat", async combat => { if (combat.id === game.combat?.id && combat.started) await ActionTracker.startTurn(combat.combatant); });
     Hooks.on("combatStart", combat => ActionTracker.startTurn(combat.combatant));
@@ -61,10 +62,10 @@ export class TurnAssistant {
     const resolve = actor => ActionTracker.findCombatant(actor);
     game.pf2eTokenBar ??= {};
     game.pf2eTokenBar.actions = {
-      consume: (actor, cost = 1, label = "Macro") => ActionTracker.record(resolve(actor), { resource: "action", cost, label }),
-      refund: (actor, cost = 1) => ActionTracker.adjust(resolve(actor), Math.abs(cost)),
-      consumeReaction: (actor, label = "Macro") => ActionTracker.record(resolve(actor), { resource: "reaction", cost: 1, label }),
-      restoreReaction: async actor => { const combatant = resolve(actor); const state = await ActionState.read(combatant); if (!state) return false; state.reaction.available = true; return ActionState.write(combatant, state); },
+      consume: (actor, cost = 1, label = "Macro") => ActionTracker.consume(resolve(actor), cost, label),
+      refund: (actor, cost = 1) => ActionTracker.refund(resolve(actor), cost),
+      consumeReaction: (actor, label = "Macro") => ActionTracker.consumeReaction(resolve(actor), label),
+      restoreReaction: actor => ActionTracker.restoreReaction(resolve(actor)),
       record: ({ actor, type, cost = 0, label = "Macro" }) => ActionTracker.record(resolve(actor), { resource: type, cost, label }),
       undo: actor => ActionTracker.undo(resolve(actor)),
     };

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -42,10 +42,9 @@ export class PF2eAdapter {
     return message?.flags?.pf2e?.context ?? null;
   }
 
-  static getPreparedActionCount(actor) {
-    const prepared = actor?.system?.attributes?.actions;
-    const value = Number(prepared?.value ?? prepared?.max);
-    return Number.isInteger(value) && value >= 0 && value <= 3 ? value : null;
+  /** PF2e does not expose a prepared per-turn action total; conditions remain warnings. */
+  static getDefaultActionCount() {
+    return 3;
   }
   static getParty() {
     return game.actors?.party ?? null;

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -492,7 +492,7 @@ class PF2ETokenBar {
       }
     }
 
-    tokens.forEach(async token => {
+    for (const token of tokens) {
       const actor = token.actor;
       const wrapper = document.createElement("div");
       wrapper.classList.add("pf2e-token-wrapper");
@@ -836,11 +836,11 @@ class PF2ETokenBar {
 
       if (combatant?.id === activeCombat?.combatant?.id) {
         const assistant = await TurnAssistant.render(combatant);
-        if (assistant && wrapper.isConnected) wrapper.appendChild(assistant);
+        if (assistant) wrapper.appendChild(assistant);
       }
 
       tokenContainer.appendChild(wrapper);
-    });
+    }
 
     const controls = document.createElement("div");
     controls.classList.add("pf2e-token-bar-controls");


### PR DESCRIPTION
### Motivation

- Ensure the Encounter Turn Assistant reliably appears for the active combatant and remove fragile DOM timing checks that prevented rendering.
- Eliminate `async` `forEach` usage to avoid un-awaited async callbacks during token rendering.
- Fix permission/permission-error issues by routing all state-mutating manual actions through a single deterministic authority (GM) and avoid local player writes to combatant flags.

### Description

- Rendering fixes: replace `tokens.forEach(async ...)` with a sequential `for...of` and remove the pre-insertion `wrapper.isConnected` check so `TurnAssistant.render()` results are appended reliably before `wrapper` is inserted. (`scripts/token-bar.js`)
- Authority request layer: add a small, typed socket request system on channel `module.pf2e-token-bar` to route write operations from players to the deterministic authority GM, including `requestId`, `senderId`, `operation`, `combatantId` and `payload`. The authority validates, deduplicates and dispatches only allowlisted operations via an explicit `switch`. (`scripts/encounter/turn-assistant/action-tracker.js`)
- Public API kept and made authority-safe: `game.pf2eTokenBar.actions` now delegates to the tracker methods that decide to execute locally (if authority) or emit a request. (`scripts/encounter/turn-assistant/turn-assistant.js`)
- Local mutation handlers preserved and adapted: existing `record`/`adjust`/`undo` semantics (including `before` history and no-negative clamping) were preserved and exposed as `*Local` internal handlers invoked by the authority dispatcher. (`scripts/encounter/turn-assistant/action-tracker.js`)
- Strike detector confidence: refined the `StrikeDetector` to treat unambiguous PF2e-v14 strike messages as `confidence: "certain"` so conservative tracking catches normal strikes. (`scripts/encounter/turn-assistant/detectors/strike-detector.js`)
- Prepared-action source cleaned up: removed reliance on `actor.system.attributes.actions` and added a conservative `PF2eAdapter.getDefaultActionCount()` returning `3` to avoid incorrect action-economy assumptions. (`scripts/integrations/pf2e.js`) 
- Socket listener registration made idempotent and invoked once during hook registration to avoid listener leaks. (`scripts/encounter/turn-assistant/action-tracker.js`, `scripts/encounter/turn-assistant/turn-assistant.js`)
- Files changed: `scripts/token-bar.js`, `scripts/encounter/turn-assistant/action-tracker.js`, `scripts/encounter/turn-assistant/turn-assistant.js`, `scripts/encounter/turn-assistant/detectors/strike-detector.js`, `scripts/integrations/pf2e.js`.

### Testing

- Static syntax check: `find scripts -name '*.js' -print0 | xargs -0 -n1 node --check` — passed.
- Relative-import and circular-import graph check (custom Python script) — checked 15 modules, imports resolve and no circular imports detected — passed.
- Targeted pattern checks: ensured no `tokens.forEach(async` and no `wrapper.isConnected` pre-insertion dependency remain — passed.
- Socket/authority logic unit-style mock test: ran a Node.js mock harness verifying deterministic authority selection (two active GMs), player→GM emit behavior, ownership validation, request deduplication, action clamping (no negative actions) and undo restoring previous `before` state — all checks passed (`authority routing, validation, deduplication, clamping, and undo checks passed`).
- Hook/registration checks: confirmed `ActionTracker.registerSocket()` is called exactly once via `registerHooks()` and the socket listener is idempotent — passed.
- Git & diff sanity checks: `git diff --check` and diff-pattern checks for accidental `$(` or jQuery additions — passed.

All automated checks performed here succeeded; runtime multi-client acceptance tests in a real Foundry VTT v14 environment (multiple clients connected) were not executed in this environment and remain recommended as a final acceptance step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79dda29d908327a33666bd7e9c946b)