### PR TITLE
Ignore PF2e reroll messages in turn assistant detectors

### DIFF
--- a/scripts/encounter/turn-assistant/detectors/activity-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/activity-detector.js
@@ -4,6 +4,7 @@ import { PF2eAdapter } from "../../../integrations/pf2e.js";
 export class ActivityDetector {
   static detect(message) {
     const context = PF2eAdapter.getMessageContext(message);
+    if (PF2eAdapter.isRerollMessage(message)) return null;
     const actor = PF2eAdapter.resolveMessageActor(message);
     const item = PF2eAdapter.resolveMessageItem(message);
     const cost = PF2eAdapter.getActionCost(item);

--- a/scripts/encounter/turn-assistant/detectors/strike-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/strike-detector.js
@@ -3,6 +3,7 @@ import { PF2eAdapter } from "../../../integrations/pf2e.js";
 export class StrikeDetector {
   static detect(message) {
     const context = PF2eAdapter.getMessageContext(message);
+    if (PF2eAdapter.isRerollMessage(message)) return null;
     if (context?.type !== "attack-roll") return null;
     const actor = PF2eAdapter.resolveMessageActor(message);
     const item = PF2eAdapter.resolveMessageItem(message);

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -42,6 +42,11 @@ export class PF2eAdapter {
     return message?.flags?.pf2e?.context ?? null;
   }
 
+  static isRerollMessage(message) {
+    const context = this.getMessageContext(message);
+    return context?.isReroll === true || message?.isReroll === true;
+  }
+
   /** PF2e does not expose a prepared per-turn action total; conditions remain warnings. */
   static getDefaultActionCount() {
     return 3;


### PR DESCRIPTION
### Motivation

- Fix a bug where PF2e Hero Point / reroll ChatMessages were treated as new Strikes and deducted a second Action. 
- Ensure the generic Activity detector also never treats a PF2e reroll as a new action so no extra Action/Reaction/History entry is created.

### Description

- Add a small helper `PF2eAdapter.isRerollMessage(message)` that returns true when `flags.pf2e.context.isReroll === true` or `message.isReroll === true`.
- Add an early guard to `StrikeDetector.detect` that returns `null` when `PF2eAdapter.isRerollMessage(message)` is true, leaving the existing Strike detection and identity (`message:${message.id}`) unchanged.
- Add the same early guard to `ActivityDetector.detect` so generic activities also ignore reroll messages.
- No other logic, UI, socket/authority handling, Action State / Undo / public API, damage/healing deduplication, or message-identity deduplication was changed.

### Testing

- Ran syntax checks with `find scripts -name "*.js" -print0 | xargs -0 -n1 node --check` and it passed without errors.
- Executed a node-based assertion script that validated: normal Strike consumes an action, an Attack-roll reroll (context and getter forms) returns `null`, ActivityDetector ignores rerolls, Damage and Critical Damage remain ignored, and a second real Strike still reports `cost: 1`; all assertions passed.
- Ran `git diff --check` (no whitespace/syntax issues) and verified the three modified files are minimal and focused on the reroll guard.

Files changed: `scripts/integrations/pf2e.js`, `scripts/encounter/turn-assistant/detectors/strike-detector.js`, `scripts/encounter/turn-assistant/detectors/activity-detector.js`.

Reroll recognition: rerolls are detected by `PF2eAdapter.isRerollMessage`, which checks `flags.pf2e.context.isReroll === true` and `message.isReroll === true`.

Both `StrikeDetector` and `ActivityDetector` are now protected by the same guard, and no other behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7abdefd438832795a7a018d18894c9)