### PR TITLE
Fix async token bar render

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -399,7 +399,7 @@ class PF2ETokenBar {
     });
   }
 
-  static render() {
+  static async render() {
     PF2ERingMenu.close();
     if (!canvas?.ready) return;
     if (!game.settings.get("pf2e-token-bar", "enabled")) {


### PR DESCRIPTION
### Motivation
- Fix a syntax error caused by `await TurnAssistant.render(combatant);` being used inside a non-`async` `static render()` which prevented the Token Bar ES module from parsing and the bar from appearing.

### Description
- Change the method signature in `scripts/token-bar.js` from `static render()` to `static async render()` and leave all render logic and surrounding code unchanged so the existing sequential token loop and Turn Assistant insertion remain intact.

### Testing
- Ran `node --check scripts/token-bar.js` and `find scripts -name "*.js" -print0 | xargs -0 -n1 node --check` (both passed), verified no `async forEach` occurrences under `scripts`, and confirmed `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ad96bb96883279597c68bf76f4aad)