### PR TITLE
Add automatic token movement tracking with PF2e movement-intent deduplication

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -93,6 +93,26 @@
           "Hint": "Konservativ bucht nur sichere Events; Automatisch auch Events mit hoher Sicherheit.",
           "Conservative": "Konservativ",
           "Automatic": "Automatisch"
+        },
+        "AutomaticMovementTracking": {
+          "Name": "Automatisches Token-Movement-Tracking aktivieren",
+          "Hint": "Verbraucht eine Aktion, nachdem der aktive Kampfteilnehmer eine zusammenhängende Tokenbewegung beendet hat."
+        },
+        "OnlyTrackActiveCombatant": {
+          "Name": "Nur aktiven Kampfteilnehmer tracken",
+          "Hint": "Ignoriert implizite Tokenbewegungen von Kampfteilnehmern, die nicht am Zug sind."
+        },
+        "IgnoreGMMovementOfPlayerTokens": {
+          "Name": "SL-Bewegung von Spieler-Tokens ignorieren",
+          "Hint": "Verbraucht keine Aktion, wenn ein SL einen spielerkontrollierten Akteur verschiebt; aktive NSC werden weiterhin getrackt."
+        },
+        "MovementDetectionDelay": {
+          "Name": "Movement-Erkennungsverzögerung (ms)",
+          "Hint": "Zeit ohne Positionsupdate, nach der eine zusammenhängende Bewegung als beendet gilt."
+        },
+        "MovementIntentTimeout": {
+          "Name": "Movement-Intent-Zeitlimit (ms)",
+          "Hint": "Zeitraum, in dem eine bereits bezahlte PF2e-Bewegungsaktivität die folgende implizite Bewegungsbuchung unterdrückt."
         }
       }
     },
@@ -201,7 +221,8 @@
       "SpendAction": "1 Aktion verbrauchen",
       "RestoreAction": "1 Aktion wiederherstellen",
       "Undo": "Rückgängig",
-      "EndTurn": "Zug beenden"
+      "EndTurn": "Zug beenden",
+      "Movement": "Bewegung"
     }
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -93,6 +93,26 @@
           "Hint": "Conservative tracks only certain events; Automatic also tracks high-confidence events.",
           "Conservative": "Conservative",
           "Automatic": "Automatic"
+        },
+        "AutomaticMovementTracking": {
+          "Name": "Enable Automatic Token Movement Tracking",
+          "Hint": "Spend one action after the active combatant completes a continuous token movement."
+        },
+        "OnlyTrackActiveCombatant": {
+          "Name": "Only Track Active Combatant",
+          "Hint": "Ignore implicit token movement by combatants whose turn is not active."
+        },
+        "IgnoreGMMovementOfPlayerTokens": {
+          "Name": "Ignore GM Movement of Player Tokens",
+          "Hint": "Do not spend actions when a GM repositions a player-owned actor; active NPC movement is still tracked."
+        },
+        "MovementDetectionDelay": {
+          "Name": "Movement Detection Delay (ms)",
+          "Hint": "Time without position updates before a continuous movement is considered complete."
+        },
+        "MovementIntentTimeout": {
+          "Name": "Movement Intent Timeout (ms)",
+          "Hint": "How long a paid PF2e movement activity can suppress the following implicit movement cost."
         }
       }
     },
@@ -201,7 +221,8 @@
       "SpendAction": "Spend 1 action",
       "RestoreAction": "Restore 1 action",
       "Undo": "Undo",
-      "EndTurn": "End Turn"
+      "EndTurn": "End Turn",
+      "Movement": "Movement"
     }
   }
 }

--- a/scripts/encounter/turn-assistant/action-tracker.js
+++ b/scripts/encounter/turn-assistant/action-tracker.js
@@ -2,6 +2,7 @@ import { PF2eAdapter } from "../../integrations/pf2e.js";
 import { ActionState } from "./action-state.js";
 import { ActivityDetector } from "./detectors/activity-detector.js";
 import { StrikeDetector } from "./detectors/strike-detector.js";
+import { MovementIntent } from "./movement-intent.js";
 
 const MODULE_ID = "pf2e-token-bar";
 const SOCKET_CHANNEL = `module.${MODULE_ID}`;
@@ -98,7 +99,7 @@ export class ActionTracker {
       case "consumeReaction": return this.recordLocal(combatant, { resource: "reaction", cost: 1, label: payload.label ?? "Macro", identity: payload.identity });
       case "restoreReaction": return this.restoreReactionLocal(combatant, payload.identity);
       case "undo": return this.undoLocal(combatant);
-      case "record": return this.recordLocal(combatant, { resource: payload.resource, cost: payload.cost, label: payload.label, identity: payload.identity });
+      case "record": return this.recordLocal(combatant, { resource: payload.resource, cost: payload.cost, label: payload.label, identity: payload.identity, automatic: payload.automatic, source: payload.source });
       default: return false;
     }
   }
@@ -149,7 +150,7 @@ export class ActionTracker {
       state.overSpent ||= spend > state.actions.remaining;
       state.actions.remaining = Math.max(0, state.actions.remaining - spend);
     } else if (event.resource === "reaction") state.reaction.available = false;
-    state.history.push({ id: event.identity ?? foundry.utils.randomID(), label: event.label, resource: event.resource, cost: event.cost, automatic: event.automatic ?? false, timestamp: Date.now(), before });
+    state.history.push({ id: event.identity ?? foundry.utils.randomID(), label: event.label, resource: event.resource, cost: event.cost, automatic: event.automatic ?? false, source: event.source, timestamp: Date.now(), before });
     if (event.identity) state.processed.push(event.identity);
     state.processed = state.processed.slice(-100);
     await ActionState.write(combatant, state);
@@ -169,7 +170,10 @@ export class ActionTracker {
       const combatant = this.findCombatant(event.actorId);
       if (combatant) {
         this.debug("Detected action", { label: event.label, actorId: event.actorId, cost: event.cost, confidence: event.confidence, messageId: message.id });
-        await this.recordLocal(combatant, { ...event, automatic: true });
+        const recorded = await this.recordLocal(combatant, { ...event, automatic: true });
+        if (recorded && event.movement && event.resource === "action") {
+          MovementIntent.add({ actorId: event.actorId, combatantId: combatant.id, slug: event.slug, cost: event.cost, identity: event.identity });
+        }
       }
       return;
     }

--- a/scripts/encounter/turn-assistant/detectors/activity-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/activity-detector.js
@@ -18,6 +18,8 @@ export class ActivityDetector {
       actorId: actor.id, resource: cost.type, cost: cost.value,
       label: item.name ?? message.flavor ?? "PF2e Activity",
       confidence: "certain", identity: `message:${message.id}`,
+      movement: PF2eAdapter.isMovementActivity(item),
+      slug: PF2eAdapter.getActivitySlug(item),
     };
   }
 }

--- a/scripts/encounter/turn-assistant/movement-intent.js
+++ b/scripts/encounter/turn-assistant/movement-intent.js
@@ -1,0 +1,41 @@
+const MODULE_ID = "pf2e-token-bar";
+
+/** Short-lived, authority-local receipts for already-paid PF2e movement activities. */
+export class MovementIntent {
+  static intents = new Map();
+
+  static key(actorId, combatantId) {
+    return `${actorId}:${combatantId}`;
+  }
+
+  static add({ actorId, combatantId, slug, cost, identity }) {
+    if (!actorId || !combatantId) return;
+    this.prune();
+    const key = this.key(actorId, combatantId);
+    const queue = this.intents.get(key) ?? [];
+    queue.push({ actorId, combatantId, slug, cost, identity, paid: true, createdAt: Date.now() });
+    this.intents.set(key, queue);
+  }
+
+  static consume(actorId, combatantId) {
+    this.prune();
+    const key = this.key(actorId, combatantId);
+    const queue = this.intents.get(key);
+    const intent = queue?.shift() ?? null;
+    if (!queue?.length) this.intents.delete(key);
+    return intent;
+  }
+
+  static prune(now = Date.now()) {
+    const ttl = Number(game.settings.get(MODULE_ID, "movementIntentTimeout")) || 8000;
+    for (const [key, queue] of this.intents) {
+      const current = queue.filter(intent => now - intent.createdAt <= ttl);
+      if (current.length) this.intents.set(key, current);
+      else this.intents.delete(key);
+    }
+  }
+
+  static clear() {
+    this.intents.clear();
+  }
+}

--- a/scripts/encounter/turn-assistant/movement-tracker.js
+++ b/scripts/encounter/turn-assistant/movement-tracker.js
@@ -1,0 +1,105 @@
+import { ActionTracker } from "./action-tracker.js";
+import { MovementIntent } from "./movement-intent.js";
+
+const MODULE_ID = "pf2e-token-bar";
+const POSITION_KEYS = ["x", "y", "elevation"];
+
+/** Debounces TokenDocument updates and turns one continuous move into one action event. */
+export class MovementTracker {
+  static pending = new Map();
+  static sequence = 0;
+
+  static registerHooks() {
+    Hooks.on("updateToken", (token, changes, options, userId) => this.onTokenUpdate(token, changes, options, userId));
+    Hooks.on("deleteCombat", () => this.clear());
+    Hooks.on("updateCombat", combat => { if (!combat.started) this.clear(); });
+    Hooks.on("canvasTearDown", () => this.clear());
+  }
+
+  static onTokenUpdate(token, changes, options = {}, userId) {
+    if (!POSITION_KEYS.some(key => Object.prototype.hasOwnProperty.call(changes, key))) return;
+    if (!game.settings.get(MODULE_ID, "turnAssistant") || !game.settings.get(MODULE_ID, "automaticMovementTracking")) return;
+    if (!ActionTracker.isAuthority() || game.paused) return;
+
+    const combat = game.combat;
+    if (!combat?.started || !combat.combatant || !token?.actor) return;
+    const combatant = this.findCombatant(token, combat);
+    if (!combatant) return;
+    if (game.settings.get(MODULE_ID, "onlyTrackActiveCombatant") && combatant.id !== combat.combatant.id) return;
+    if (this.ignoreGMMovement(token.actor, userId)) return;
+
+    const key = `${token.parent?.id ?? token.scene?.id ?? "scene"}:${token.id}`;
+    const position = this.position(token, changes);
+    let session = this.pending.get(key);
+    if (!session) {
+      session = {
+        tokenId: token.id, actorId: token.actor.id, combatId: combat.id, combatantId: combatant.id,
+        sessionId: `${Date.now().toString(36)}-${++this.sequence}`, startedAt: Date.now(),
+        lastUpdate: Date.now(), position, timer: null,
+      };
+      this.pending.set(key, session);
+      ActionTracker.debug("Movement started", { actor: token.actor.name, token: token.name });
+    } else {
+      if (this.samePosition(session.position, position)) return;
+      session.position = position;
+      session.lastUpdate = Date.now();
+      clearTimeout(session.timer);
+      ActionTracker.debug("Movement update received", { actor: token.actor.name, token: token.name });
+    }
+    const delay = Number(game.settings.get(MODULE_ID, "movementDetectionDelay")) || 400;
+    session.timer = setTimeout(() => this.finishMovement(key), delay);
+  }
+
+  static async finishMovement(key) {
+    const session = this.pending.get(key);
+    if (!session) return;
+    this.pending.delete(key);
+    clearTimeout(session.timer);
+    const combat = game.combat;
+    const combatant = ActionTracker.getCombatant(session.combatantId);
+    if (!combat?.started || combat.id !== session.combatId || !combatant || game.paused) return;
+    if (game.settings.get(MODULE_ID, "onlyTrackActiveCombatant") && combat.combatant?.id !== combatant.id) return;
+
+    ActionTracker.debug("Movement completed", session);
+    const intent = MovementIntent.consume(session.actorId, session.combatantId);
+    if (intent) {
+      ActionTracker.debug("Movement intent found; skipping additional movement cost", intent);
+      return;
+    }
+    const identity = `movement:${session.combatId}:${session.combatantId}:${session.sessionId}`;
+    ActionTracker.debug("No movement intent found; spending 1 action", { identity });
+    await ActionTracker.record(combatant, {
+      resource: "action", cost: 1,
+      label: game.i18n.localize("PF2ETokenBar.TurnAssistant.Movement"),
+      automatic: true, source: "token-movement", identity,
+    });
+  }
+
+  static findCombatant(token, combat) {
+    const tokenId = token.id;
+    const sceneId = token.parent?.id ?? token.scene?.id;
+    return combat.combatants.find(combatant =>
+      (combatant.tokenId === tokenId && (!combatant.sceneId || !sceneId || combatant.sceneId === sceneId))
+      || (combatant.actorId === token.actor?.id && combatant.id === combat.combatant?.id)
+    ) ?? null;
+  }
+
+  static ignoreGMMovement(actor, userId) {
+    if (!game.settings.get(MODULE_ID, "ignoreGMMovementOfPlayerTokens") || !actor?.hasPlayerOwner) return false;
+    return game.users?.get?.(userId)?.isGM === true;
+  }
+
+  static position(token, changes) {
+    return Object.fromEntries(POSITION_KEYS.map(key => [key, changes[key] ?? token[key] ?? token._source?.[key] ?? 0]));
+  }
+
+  static samePosition(a, b) {
+    return POSITION_KEYS.every(key => a[key] === b[key]);
+  }
+
+  static clear() {
+    for (const session of this.pending.values()) clearTimeout(session.timer);
+    this.pending.clear();
+    MovementIntent.clear();
+  }
+}

--- a/scripts/encounter/turn-assistant/turn-assistant.js
+++ b/scripts/encounter/turn-assistant/turn-assistant.js
@@ -2,6 +2,7 @@ import { PF2eAdapter } from "../../integrations/pf2e.js";
 import { ActionState } from "./action-state.js";
 import { ActionTracker } from "./action-tracker.js";
 import { TurnWarnings } from "./turn-warnings.js";
+import { MovementTracker } from "./movement-tracker.js";
 
 const MODULE_ID = "pf2e-token-bar";
 
@@ -51,6 +52,7 @@ export class TurnAssistant {
   static registerHooks(render) {
     ActionTracker.onChange = render;
     ActionTracker.registerSocket();
+    MovementTracker.registerHooks();
     Hooks.on("createChatMessage", message => ActionTracker.processMessage(message));
     Hooks.on("updateCombat", async combat => { if (combat.id === game.combat?.id && combat.started) await ActionTracker.startTurn(combat.combatant); });
     Hooks.on("combatStart", combat => ActionTracker.startTurn(combat.combatant));

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -9,6 +9,7 @@ function warnOnce(api) {
 
 /** The deliberately small boundary around PF2e's public, version-sensitive APIs. */
 export class PF2eAdapter {
+  static MOVEMENT_ACTION_SLUGS = new Set(["stride", "step", "climb", "swim", "crawl", "sneak", "leap", "high-jump", "long-jump", "fly"]);
   static ACTION_GLYPHS = Object.freeze({ action: "1", action2: "2", action3: "3", reaction: "R", free: "F" });
 
   static getActionGlyph(type = "action", value = 1) {
@@ -28,6 +29,16 @@ export class PF2eAdapter {
     const value = cost.type === "action" ? Number(cost.value) : cost.type === "reaction" ? 1 : 0;
     if (cost.type === "action" && ![1, 2, 3].includes(value)) return null;
     return { type: cost.type, value };
+  }
+
+  static getActivitySlug(item) {
+    return item?.slug ?? item?.system?.slug ?? null;
+  }
+
+  static isMovementActivity(item) {
+    const traits = item?.system?.traits?.value ?? item?.traits;
+    if (traits?.has?.("move") || (Array.isArray(traits) && traits.includes("move"))) return true;
+    return this.MOVEMENT_ACTION_SLUGS.has(this.getActivitySlug(item));
   }
 
   static resolveMessageActor(message) {

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -130,6 +130,20 @@ Hooks.once("init", () => {
     name: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Name`), hint: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Hint`), scope, config: true, type: Boolean, default: defaultValue, onChange: () => PF2ETokenBar.render(),
   });
   game.settings.register("pf2e-token-bar", "trackingMode", { name: game.i18n.localize("PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Name"), hint: game.i18n.localize("PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Hint"), scope: "world", config: true, type: String, choices: { conservative: "PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Conservative", automatic: "PF2ETokenBar.Settings.TurnAssistant.TrackingMode.Automatic" }, default: "conservative" });
+  const movementBooleans = [
+    ["automaticMovementTracking", "AutomaticMovementTracking", true],
+    ["onlyTrackActiveCombatant", "OnlyTrackActiveCombatant", true],
+    ["ignoreGMMovementOfPlayerTokens", "IgnoreGMMovementOfPlayerTokens", true],
+  ];
+  for (const [key, label, defaultValue] of movementBooleans) game.settings.register("pf2e-token-bar", key, {
+    name: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Name`), hint: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Hint`), scope: "world", config: true, type: Boolean, default: defaultValue,
+  });
+  for (const [key, label, defaultValue, range] of [
+    ["movementDetectionDelay", "MovementDetectionDelay", 400, { min: 100, max: 2000, step: 100 }],
+    ["movementIntentTimeout", "MovementIntentTimeout", 8000, { min: 1000, max: 30000, step: 1000 }],
+  ]) game.settings.register("pf2e-token-bar", key, {
+    name: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Name`), hint: game.i18n.localize(`PF2ETokenBar.Settings.TurnAssistant.${label}.Hint`), scope: "world", config: true, type: Number, range, default: defaultValue,
+  });
 });
 
 class PF2ETokenBar {


### PR DESCRIPTION
### Motivation

- Provide automatic implicit Movement spending when the active combatant completes a continuous token move while reusing the existing ActionTracker/authority/socket/history/undo infrastructure.
- Avoid double-charging when a PF2e movement activity (e.g. Climb/Stride/Step/Swim/etc.) was already paid via chat by introducing a short-lived intent that suppresses the following implicit token-move charge.
- Keep behavior conservative and configurable: only track during active combats by default, prefer PF2e system data (traits/slugs) over localized labels, and never block token movement.

### Description

- Added a new `MovementTracker` component (`scripts/encounter/turn-assistant/movement-tracker.js`) that registers the Foundry V14 `updateToken` hook, debounces per scene/token position updates, and turns one continuous movement session into one `ActionTracker.record(...)` event after a configurable delay (default `400 ms`).
- Added a `MovementIntent` queue (`scripts/encounter/turn-assistant/movement-intent.js`) that stores per-actor/combatant short-lived receipts for movement activities (default TTL `8000 ms`) and is consumed by `MovementTracker` to deduplicate chat-paid activities and token movement.
- Extended the PF2e adapter (`scripts/integrations/pf2e.js`) with `MOVEMENT_ACTION_SLUGS`, `getActivitySlug(...)`, and `isMovementActivity(...)` to detect movement activities from PF2e data using traits and slugs rather than localized names.
- Wired activity detection to produce movement metadata (`slug` and `movement`) in `ActivityDetector`, and made `ActionTracker.processMessage` create an intent when a movement activity is recorded; `ActionTracker.recordLocal` was extended to include `source` for history entries.
- Added world/client settings and localization keys for movement: `AutomaticMovementTracking`, `OnlyTrackActiveCombatant`, `IgnoreGMMovementOfPlayerTokens`, `MovementDetectionDelay`, and `MovementIntentTimeout`, with EN/DE translations and sensible defaults; movement events use `source: "token-movement"` and an identity like `movement:<combatId>:<combatantId>:<sessionId>` to avoid double-processing.
- Cleanup hooks ensure pending sessions and intents are cleared on `deleteCombat`, non-started `updateCombat`, and `canvasTearDown`, and the implementation uses the existing authority checks so only the authoritative client mutates action state.

### Testing

- Verified JavaScript syntax for all `scripts/*.js` files with `node --check`, and validated JSON for `lang/en.json`, `lang/de.json` and `module.json`, all succeeding.
- Ran an import-resolution scan for relative `import` paths which reported all relative imports resolve successfully.
- Executed a local behavioral test script that simulates multiple intermediate token updates and confirmed exactly one `ActionTracker.record` was generated, MovementIntent successfully deduplicated a prior paid movement, GM movement of player-owned tokens was ignored by default, movement outside an encounter was ignored, and intents expire after the configured TTL; all checks passed.
- Ran repository checks (`git diff --check`) and confirmed no whitespace/patch errors; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae850a7288327a1a9ae19418e75cc)