### PR TITLE
Detect PF2e system movement actions and apply Quickened/Slowed at turn start

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -222,7 +222,8 @@
       "RestoreAction": "1 Aktion wiederherstellen",
       "Undo": "Rückgängig",
       "EndTurn": "Zug beenden",
-      "Movement": "Bewegung"
+      "Movement": "Bewegung",
+      "Quickened": "Beschleunigt (die zusätzliche Aktion kann Einschränkungen haben)"
     }
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -222,7 +222,8 @@
       "RestoreAction": "Restore 1 action",
       "Undo": "Undo",
       "EndTurn": "End Turn",
-      "Movement": "Movement"
+      "Movement": "Movement",
+      "Quickened": "Quickened (the extra action may have usage restrictions)"
     }
   }
 }

--- a/scripts/encounter/turn-assistant/action-state.js
+++ b/scripts/encounter/turn-assistant/action-state.js
@@ -12,14 +12,16 @@ export class ActionState {
     return state;
   }
 
-  static create(combatant, maximum = 3, previous = null) {
+  static create(combatant, economy = 3, previous = null) {
+    const maximum = typeof economy === "number" ? economy : economy.actions;
     return {
       combatId: combatant.combat?.id ?? game.combat?.id,
       combatantId: combatant.id,
       actorId: combatant.actorId,
       turn: `${combatant.combat?.round ?? 0}:${combatant.combat?.turn ?? 0}`,
       actions: { max: maximum, remaining: maximum },
-      reaction: { available: true },
+      reaction: { available: typeof economy === "number" ? true : economy.reaction },
+      reasons: typeof economy === "number" ? [] : economy.reasons,
       history: [], pending: null, overSpent: false,
       processed: previous?.processed?.slice(-100) ?? [],
     };

--- a/scripts/encounter/turn-assistant/action-tracker.js
+++ b/scripts/encounter/turn-assistant/action-tracker.js
@@ -2,6 +2,7 @@ import { PF2eAdapter } from "../../integrations/pf2e.js";
 import { ActionState } from "./action-state.js";
 import { ActivityDetector } from "./detectors/activity-detector.js";
 import { StrikeDetector } from "./detectors/strike-detector.js";
+import { SystemActionDetector } from "./detectors/system-action-detector.js";
 import { MovementIntent } from "./movement-intent.js";
 
 const MODULE_ID = "pf2e-token-bar";
@@ -10,7 +11,7 @@ const MUTATION_TYPE = "action-tracker-mutation";
 const RESOURCES = new Set(["action", "reaction", "free"]);
 
 export class ActionTracker {
-  static detectors = [ActivityDetector, StrikeDetector];
+  static detectors = [StrikeDetector, SystemActionDetector, ActivityDetector];
   static onChange = () => {};
   static socketRegistered = false;
   static handledRequests = new Set();
@@ -109,7 +110,8 @@ export class ActionTracker {
     const old = await ActionState.read(combatant);
     const key = `${combatant.combat?.round ?? 0}:${combatant.combat?.turn ?? 0}`;
     if (old?.turn === key && old?.combatId === combatant.combat?.id) return;
-    await ActionState.write(combatant, ActionState.create(combatant, PF2eAdapter.getDefaultActionCount(), old));
+    const economy = PF2eAdapter.getTurnStartActionEconomy(combatant.actor);
+    await ActionState.write(combatant, ActionState.create(combatant, economy, old));
   }
 
   static record(combatant, event) {

--- a/scripts/encounter/turn-assistant/detectors/system-action-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/system-action-detector.js
@@ -1,0 +1,40 @@
+import { PF2eAdapter } from "../../../integrations/pf2e.js";
+
+const MODULE_ID = "pf2e-token-bar";
+
+/** Detect item-less PF2e SystemAction/SingleCheckAction movement checks. */
+export class SystemActionDetector {
+  static detect(message) {
+    if (PF2eAdapter.isRerollMessage(message)) return null;
+    const context = PF2eAdapter.getMessageContext(message);
+    if (!context) return null;
+    const slug = PF2eAdapter.getMessageActionSlug(message);
+    if (!slug) {
+      if (context.options?.some?.(option => typeof option === "string" && option.startsWith("action:"))) {
+        this.debug("System action detection skipped", { reason: "no unique action slug", messageId: message.id });
+      }
+      return null;
+    }
+    const actor = PF2eAdapter.resolveMessageActor(message);
+    const cost = PF2eAdapter.getSystemActionCost(slug);
+    const movement = PF2eAdapter.MOVEMENT_ACTION_SLUGS.has(slug) && PF2eAdapter.getMessageTraits(message).includes("move");
+    if (!actor || !cost || !movement) return null;
+    const event = {
+      actorId: actor.id,
+      resource: "action",
+      cost,
+      label: PF2eAdapter.getSystemActionLabel(slug, message),
+      slug,
+      movement: true,
+      confidence: "certain",
+      source: "pf2e-system-action",
+      identity: `message:${message.id}`,
+    };
+    this.debug("PF2e system action detected", { slug, cost, movement: true, confidence: "certain" });
+    return event;
+  }
+
+  static debug(label, data) {
+    if (game.settings.get(MODULE_ID, "debug")) console.debug(`${MODULE_ID} | ${label}`, data);
+  }
+}

--- a/scripts/encounter/turn-assistant/turn-assistant.js
+++ b/scripts/encounter/turn-assistant/turn-assistant.js
@@ -31,6 +31,11 @@ export class TurnAssistant {
     actions.title = game.i18n.format("PF2ETokenBar.TurnAssistant.ActionsRemaining", { count: state.actions.remaining }); resources.append(actions);
     const reaction = glyph("reaction"); reaction.classList.toggle("spent", !state.reaction.available); reaction.title = game.i18n.localize(`PF2ETokenBar.TurnAssistant.Reaction${state.reaction.available ? "Available" : "Spent"}`); resources.append(reaction); root.append(resources);
 
+    if (state.reasons?.some(reason => reason.type === "quickened")) {
+      const quickened = document.createElement("div"); quickened.className = "pf2e-turn-economy";
+      quickened.textContent = game.i18n.localize("PF2ETokenBar.TurnAssistant.Quickened"); root.append(quickened);
+    }
+
     const last = state.history.at(-1);
     if (last && game.settings.get(MODULE_ID, "showActionHistory")) {
       const history = document.createElement("div"); history.className = "pf2e-turn-last";

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -10,6 +10,12 @@ function warnOnce(api) {
 /** The deliberately small boundary around PF2e's public, version-sensitive APIs. */
 export class PF2eAdapter {
   static MOVEMENT_ACTION_SLUGS = new Set(["stride", "step", "climb", "swim", "crawl", "sneak", "leap", "high-jump", "long-jump", "fly"]);
+  // PF2e 7.8 (Foundry V14) SystemActions definitions. Used only if the public
+  // game.pf2e.actions collection is unavailable or does not contain the action.
+  static MOVEMENT_ACTION_COSTS = new Map([
+    ["stride", 1], ["step", 1], ["climb", 1], ["swim", 1], ["crawl", 1],
+    ["sneak", 1], ["leap", 1], ["high-jump", 2], ["long-jump", 2], ["fly", 1],
+  ]);
   static ACTION_GLYPHS = Object.freeze({ action: "1", action2: "2", action3: "3", reaction: "R", free: "F" });
 
   static getActionGlyph(type = "action", value = 1) {
@@ -53,12 +59,72 @@ export class PF2eAdapter {
     return message?.flags?.pf2e?.context ?? null;
   }
 
+  /** Resolve a unique supported action from PF2e's sorted check roll options. */
+  static getMessageActionSlug(message) {
+    const options = this.getMessageContext(message)?.options;
+    if (!Array.isArray(options)) return null;
+    const candidates = [...new Set(options
+      .filter(option => typeof option === "string" && option.startsWith("action:"))
+      .map(option => option.slice("action:".length))
+      .filter(slug => this.MOVEMENT_ACTION_SLUGS.has(slug)))];
+    if (candidates.length === 1) return candidates[0];
+    if (candidates.length < 2) return null;
+
+    // High Jump and Long Jump deliberately include action:stride and action:leap.
+    // PF2e's action definition identifies the primary slug and lists those two
+    // prerequisite roll options, allowing an unambiguous, data-driven choice.
+    const matches = candidates.filter(slug => {
+      const action = this.getSystemAction(slug);
+      const related = Array.isArray(action?.rollOptions)
+        ? action.rollOptions.filter(option => option.startsWith("action:")).map(option => option.slice(7))
+        : [];
+      return related.length > 0 && candidates.every(candidate => candidate === slug || related.includes(candidate));
+    });
+    return matches.length === 1 ? matches[0] : null;
+  }
+
+  static getMessageTraits(message) {
+    const traits = this.getMessageContext(message)?.traits;
+    return Array.isArray(traits) ? traits : [];
+  }
+
+  static getSystemAction(slug) {
+    return game.pf2e?.actions?.get?.(slug) ?? null;
+  }
+
+  static getSystemActionCost(slug) {
+    const cost = this.getSystemAction(slug)?.cost;
+    return Number.isInteger(cost) && cost > 0 ? cost : this.MOVEMENT_ACTION_COSTS.get(slug) ?? null;
+  }
+
+  static getSystemActionLabel(slug, message) {
+    const name = this.getSystemAction(slug)?.name;
+    if (typeof name === "string" && name) return game.i18n.localize(name);
+    const title = this.getMessageContext(message)?.title;
+    if (typeof title === "string" && title) return game.i18n.localize(title);
+    return message?.flavor ?? slug;
+  }
+
   static isRerollMessage(message) {
     const context = this.getMessageContext(message);
     return context?.isReroll === true || message?.isReroll === true;
   }
 
-  /** PF2e does not expose a prepared per-turn action total; conditions remain warnings. */
+  static getCondition(actor, slug) {
+    return actor?.conditions?.bySlug?.(slug, { active: true })?.[0] ?? null;
+  }
+
+  /** PF2e V14 has no prepared action total: apply only start-of-turn quickened/slowed. */
+  static getTurnStartActionEconomy(actor) {
+    const quickened = actor?.conditions?.hasType?.("quickened") === true || !!this.getCondition(actor, "quickened");
+    const slowed = this.getCondition(actor, "slowed");
+    const slowedValue = Math.max(0, Number(slowed?.badge?.value ?? slowed?.system?.badge?.value) || 0);
+    const reasons = [];
+    if (quickened) reasons.push({ type: "quickened", value: 1 });
+    if (slowedValue) reasons.push({ type: "slowed", value: slowedValue });
+    return { actions: Math.max(0, 3 + (quickened ? 1 : 0) - slowedValue), reaction: true, reasons };
+  }
+
   static getDefaultActionCount() {
     return 3;
   }

--- a/tests/turn-assistant.test.mjs
+++ b/tests/turn-assistant.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+globalThis.game = {
+  pf2e: { actions: new Map() },
+  i18n: { localize: value => value },
+  settings: { get: () => false },
+  actors: new Map(),
+};
+
+const { PF2eAdapter } = await import("../scripts/integrations/pf2e.js");
+const { SystemActionDetector } = await import("../scripts/encounter/turn-assistant/detectors/system-action-detector.js");
+
+const actions = [
+  ["climb", 1, []], ["swim", 1, []], ["sneak", 1, []], ["leap", 1, []],
+  ["high-jump", 2, ["action:stride", "action:leap"]],
+  ["long-jump", 2, ["action:stride", "action:leap"]],
+];
+for (const [slug, cost, rollOptions] of actions) {
+  game.pf2e.actions.set(slug, { slug, cost, rollOptions, name: `PF2E.Actions.${slug}.Title` });
+}
+
+function message(slug, { id = slug, actor = { id: "actor" }, traits = ["move"], options } = {}) {
+  return {
+    id, actor,
+    flags: { pf2e: { context: { type: "check", options: options ?? [`action:${slug}`], traits } } },
+  };
+}
+
+test("detects item-less PF2e movement checks and their V14 costs", () => {
+  for (const [slug, cost] of actions) {
+    const options = slug.endsWith("jump")
+      ? ["action:stride", "action:leap", `action:${slug}`]
+      : undefined;
+    const event = SystemActionDetector.detect(message(slug, { options }));
+    assert.equal(event.slug, slug);
+    assert.equal(event.cost, cost);
+    assert.equal(event.source, "pf2e-system-action");
+    assert.equal(event.movement, true);
+  }
+});
+
+test("rejects ordinary skill rolls, missing move traits, ambiguous actions, and rerolls", () => {
+  assert.equal(SystemActionDetector.detect(message("athletics", { options: [] })), null);
+  assert.equal(SystemActionDetector.detect(message("climb", { traits: [] })), null);
+  assert.equal(SystemActionDetector.detect(message("climb", { options: ["action:climb", "action:swim"] })), null);
+  const reroll = message("climb"); reroll.flags.pf2e.context.isReroll = true;
+  assert.equal(SystemActionDetector.detect(reroll), null);
+});
+
+function actorWith({ quickened = false, slowed = 0 } = {}) {
+  const conditions = new Map();
+  if (quickened) conditions.set("quickened", { slug: "quickened", active: true });
+  if (slowed) conditions.set("slowed", { slug: "slowed", active: true, badge: { value: slowed } });
+  return {
+    conditions: {
+      hasType: slug => conditions.has(slug),
+      bySlug: slug => conditions.has(slug) ? [conditions.get(slug)] : [],
+    },
+  };
+}
+
+test("calculates only quickened and slowed at turn start", () => {
+  for (const [conditions, expected] of [
+    [{}, 3], [{ quickened: true }, 4], [{ slowed: 1 }, 2], [{ slowed: 2 }, 1],
+    [{ quickened: true, slowed: 1 }, 3], [{ quickened: true, slowed: 2 }, 2], [{ slowed: 9 }, 0],
+  ]) {
+    assert.equal(PF2eAdapter.getTurnStartActionEconomy(actorWith(conditions)).actions, expected);
+  }
+});


### PR DESCRIPTION
### Motivation
- PF2e "system" actions (SingleCheckAction macros like Climb/Swim/Leap) often emit no `message.item` and must be detected from `flags.pf2e.context` instead of relying on item-based detection.  
- The per-turn action resources must reflect PF2e conditions `quickened` and `slowed` at the start of a combatant's turn rather than always initializing to 3 actions.

### Description
- Added a new `SystemActionDetector` that inspects `message.flags.pf2e.context.options` and `context.traits` to reliably detect PF2e system actions, ignores rerolls, requires a unique action slug, marks movement actions, and emits a standard tracking event with `identity: message:<id>`; new file: `scripts/encounter/turn-assistant/detectors/system-action-detector.js`.  
- Extended the PF2e adapter (`scripts/integrations/pf2e.js`) with helpers: `getMessageActionSlug`, `getMessageTraits`, `getSystemAction`, `getSystemActionCost`, `getSystemActionLabel`, `getTurnStartActionEconomy`, and `getCondition`, and added a small, PF2e-v14-verified fallback cost map for movement action slugs (`stride, step, climb, swim, crawl, sneak, leap, high-jump, long-jump, fly`) where `high-jump` and `long-jump` cost 2 actions.  
- Integrated the new detector into the pipeline and adjusted detector order to `StrikeDetector, SystemActionDetector, ActivityDetector` to avoid double-booking, and preserved the existing ActivityDetector/Item-based path. (changed: `scripts/encounter/turn-assistant/action-tracker.js`).  
- Centralized turn-start economy calculation and persisted reasons: `ActionTracker.startTurn()` now uses `PF2eAdapter.getTurnStartActionEconomy(actor)` and `ActionState.create()` accepts an economy object so the state stores `actions.max`, `actions.remaining`, `reaction`, and `reasons` (changed: `scripts/encounter/turn-assistant/action-state.js`, `scripts/encounter/turn-assistant/action-tracker.js`).  
- UI: the TurnAssistant render continues to draw one glyph per remaining action and now shows a localized Quickened hint when applicable (changed: `scripts/encounter/turn-assistant/turn-assistant.js`, updated localizations `lang/en.json` and `lang/de.json`).  
- Movement intent behavior preserved: a detected movement system action sets `movement: true` on the tracking event so the existing MovementIntent logic continues to deduplicate subsequent token movement without changes.  

### Testing
- Ran syntax/import checks with `node --check` over `scripts` and validated there are no missing relative imports, and JSON localization files parse (`python -m json.tool lang/en.json lang/de.json`), all passed.  
- Executed the unit test suite with Node (`node --experimental-default-type=module --test tests/turn-assistant.test.mjs`), which includes detection tests for Climb/Swim/Sneak/Leap/High-Jump/Long-Jump and turn-start Quickened/Slowed cases; results: 3 subtests passed (all green).  
- Confirmed `git diff --check` and basic repo checks; no syntax or import errors were reported during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7afcbef448832791abccb969500a0c)