### PR TITLE
Offer XP award when encounters end from the token bar

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -25,6 +25,10 @@
         "Name": "Schnellbeute",
         "Hint": "Überträgt nach dem Kampf automatisch die Beute besiegter NSC und öffnet den Beute-Akteur."
       },
+      "AwardXPOnEncounterEnd": {
+        "Name": "XP-Vergabe beim Encounter-Ende anbieten",
+        "Hint": "Öffnet nach dem Beenden eines Encounters über die Token Bar den Dialog zur XP-Vergabe."
+      },
       "ZeroHpInitiativePrompt": {
         "Name": "Initiativeabfrage bei 0 TP",
         "Hint": "Fragt, ob ein Gruppenmitglied bei 0 TP direkt vor den Angreifer in der Initiative einsortiert werden soll und erlaubt einen eigenen Wert."

--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,10 @@
         "Name": "Quick Loot",
         "Hint": "Automatically transfer defeated NPC loot and open the Loot actor on combat end."
       },
+      "AwardXPOnEncounterEnd": {
+        "Name": "Offer XP Award on Encounter End",
+        "Hint": "Opens the XP award dialog after ending an encounter from the token bar."
+      },
       "ZeroHpInitiativePrompt": {
         "Name": "Prompt Initiative Change at 0 HP",
         "Hint": "When a party member drops to 0 HP, ask to move them just before the attacker in initiative and allow entering a custom value."

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -78,6 +78,14 @@ Hooks.once("init", () => {
     type: Boolean,
     default: true,
   });
+  game.settings.register("pf2e-token-bar", "awardXPOnEncounterEnd", {
+    name: game.i18n.localize("PF2ETokenBar.Settings.AwardXPOnEncounterEnd.Name"),
+    hint: game.i18n.localize("PF2ETokenBar.Settings.AwardXPOnEncounterEnd.Hint"),
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
   game.settings.register("pf2e-token-bar", "zeroHpInitiativePrompt", {
     name: game.i18n.localize("PF2ETokenBar.Settings.ZeroHpInitiativePrompt.Name"),
     hint: game.i18n.localize("PF2ETokenBar.Settings.ZeroHpInitiativePrompt.Hint"),
@@ -964,6 +972,9 @@ class PF2ETokenBar {
     encounterBtn.addEventListener("click", async () => {
       try {
         if (game.combat?.started) {
+          const shouldOfferXP = game.user.isGM
+            && game.settings.get("pf2e-token-bar", "awardXPOnEncounterEnd");
+
           if (game.user.isGM && game.settings.get("pf2e-token-bar", "quickLoot")) {
             const confirmed = await ModuleDialog.confirm({
               title: game.i18n.localize("PF2ETokenBar.QuickLootConfirmTitle"),
@@ -974,7 +985,21 @@ class PF2ETokenBar {
               PF2ETokenBar.openLootActor("Loot", true);
             }
           }
-          await game.combat.endCombat();
+
+          try {
+            await game.combat.endCombat();
+          } catch (error) {
+            console.error("PF2ETokenBar | Failed to end combat", error);
+            return;
+          }
+
+          if (shouldOfferXP) {
+            try {
+              await PF2ETokenBar.awardXPDialog();
+            } catch (error) {
+              console.error("PF2ETokenBar | Failed to open XP award dialog", error);
+            }
+          }
         } else {
           await game.combat.startCombat();
 


### PR DESCRIPTION
### Motivation

- Ensure GMs are optionally prompted to award XP when ending an encounter from the Token Bar without coupling this to Quick Loot.  
- Preserve existing XP computation and existing Quick Loot behavior while keeping the flows independent.  
- Reuse the existing `awardXPDialog()` and existing localization structure.

### Description

- Added a new world setting `awardXPOnEncounterEnd` (default: `true`) and localization keys for EN/DE so GMs can opt in to the XP prompt; files changed: `scripts/token-bar.js`, `lang/en.json`, `lang/de.json`.  
- In the Token Bar End-Encounter handler the code now: determines the GM+setting guard for XP, runs the existing Quick Loot flow unchanged, awaits `game.combat.endCombat()` and only then (if allowed and for GMs) calls `PF2ETokenBar.awardXPDialog()`; errors from `endCombat()` or the XP dialog are logged and handled without changing combat state.  
- The manual XP button remains unchanged and still calls `awardXPDialog()` directly, and the global `combatEnd` hook is left untouched to avoid double-opening the dialog.  
- No changes to existing XP calculations, loot transfer functions, or PF2e APIs were made; no broad refactor was performed.

### Testing

- `find scripts -name "*.js" -print0 | xargs -0 -n1 node --check` succeeded with no syntax errors.  
- JSON parsing of `lang/en.json` and `lang/de.json` succeeded (localization JSON valid).  
- `node --test tests/*.test.mjs` ran the test suite (3 tests) and all passed.  
- A search for relevant occurrences confirmed the new setting and the single XP-dialog call site in the Token Bar handler and that the manual XP button remains intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b15ee5ba08327ba74552ae951302e)