### PR TITLE
Fix encounter reaction display and PF2e reaction-card detection

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -218,6 +218,12 @@
       "ActionsRemaining": "{count} Aktionen verbleibend",
       "ReactionAvailable": "Reaktion verfügbar",
       "ReactionSpent": "Reaktion verbraucht",
+      "Reactions": {
+        "Available": "Verfügbar",
+        "Spent": "Verbraucht",
+        "FirstTurn": "Verfügbar zu Beginn des ersten eigenen Zuges",
+        "NextTurn": "Wird zu Beginn des nächsten eigenen Zuges erneuert"
+      },
       "Last": "Zuletzt: {label}",
       "AdditionalAction": "Weitere Aktion erkannt, nachdem alle Aktionen verbraucht waren.",
       "ManualSpend": "Aktion manuell verbraucht",

--- a/lang/en.json
+++ b/lang/en.json
@@ -218,6 +218,12 @@
       "ActionsRemaining": "{count} actions remaining",
       "ReactionAvailable": "Reaction available",
       "ReactionSpent": "Reaction spent",
+      "Reactions": {
+        "Available": "Available",
+        "Spent": "Spent",
+        "FirstTurn": "Available at the start of this combatant's first turn",
+        "NextTurn": "Refreshes at the start of this combatant's next turn"
+      },
       "Last": "Last: {label}",
       "AdditionalAction": "Additional action detected after all actions were spent.",
       "ManualSpend": "Manual action spent",

--- a/scripts/encounter/turn-assistant/action-state.js
+++ b/scripts/encounter/turn-assistant/action-state.js
@@ -16,7 +16,7 @@ export class ActionState {
     return state;
   }
 
-  static create(combatant, economy = 3, previous = null) {
+  static create(combatant, economy = 3, previous = null, { reactionsInitialized = true } = {}) {
     const maximum = typeof economy === "number" ? economy : economy.actions;
     return {
       combatId: combatant.combat?.id ?? game.combat?.id,
@@ -24,7 +24,8 @@ export class ActionState {
       actorId: combatant.actorId,
       turn: `${combatant.combat?.round ?? 0}:${combatant.combat?.turn ?? 0}`,
       actions: { max: maximum, remaining: maximum },
-      reactions: { version: REACTION_SCHEMA_VERSION, general: generalSlot(typeof economy === "number" || economy.reaction ? 1 : 0), bonus: [] },
+      reactions: { version: REACTION_SCHEMA_VERSION, initialized: reactionsInitialized,
+        general: generalSlot(reactionsInitialized && (typeof economy === "number" || economy.reaction) ? 1 : 0), bonus: [] },
       reasons: typeof economy === "number" ? [] : economy.reasons,
       history: [], pending: null, overSpent: false,
       processed: previous?.processed?.slice(-100) ?? [],

--- a/scripts/encounter/turn-assistant/action-tracker.js
+++ b/scripts/encounter/turn-assistant/action-tracker.js
@@ -6,6 +6,7 @@ import { SystemActionDetector } from "./detectors/system-action-detector.js";
 import { MovementIntent } from "./movement-intent.js";
 import { ReactionTracker } from "./reaction/reaction-tracker.js";
 import { allReactionSlots } from "./reaction/reaction-state.js";
+import { REACTION_STRIKE_SLUGS } from "./reaction/reaction-registry.js";
 
 const MODULE_ID = "pf2e-token-bar";
 const SOCKET_CHANNEL = `module.${MODULE_ID}`;
@@ -17,6 +18,7 @@ export class ActionTracker {
   static onChange = () => {};
   static socketRegistered = false;
   static handledRequests = new Set();
+  static reactionStrikeIntents = new Map();
 
   static getAuthorityUser() {
     return game.users?.filter(user => user.active && user.isGM).sort((a, b) => a.id.localeCompare(b.id))[0] ?? null;
@@ -120,6 +122,8 @@ export class ActionTracker {
     const state = ActionState.create(combatant, economy, old);
     if (old) { state.reactions = old.reactions; ReactionTracker.reconcile(state, combatant.actor); ReactionTracker.refresh(state, "start-own-turn"); ReactionTracker.refresh(state, "start-next-own-turn"); }
     else ReactionTracker.reconcile(state, combatant.actor);
+    this.debug("Own turn started: initializing/refreshing reactions", { actor: combatant.actor?.name, initialized: state.reactions.initialized,
+      slots: allReactionSlots(state.reactions).map(slot => ({ label: slot.label, remaining: slot.remaining })) });
     await ActionState.write(combatant, state);
   }
 
@@ -176,7 +180,8 @@ export class ActionTracker {
 
   static async recordLocal(combatant, event) {
     if (!combatant || !event) return false;
-    const state = await ActionState.read(combatant) ?? ActionState.create(combatant, PF2eAdapter.getDefaultActionCount());
+    const state = await ActionState.read(combatant)
+      ?? ActionState.create(combatant, PF2eAdapter.getDefaultActionCount(), null, { reactionsInitialized: false });
     if (event.identity && state.processed.includes(event.identity)) return false;
     ReactionTracker.reconcile(state, combatant.actor);
     const before = { actions: state.actions.remaining };
@@ -186,7 +191,11 @@ export class ActionTracker {
       state.actions.remaining = Math.max(0, state.actions.remaining - spend);
     } else if (event.resource === "reaction") {
       const spent = ReactionTracker.spend(state, event);
-      if (!spent) return false;
+      if (!spent) {
+        this.debug("Reaction state has no available matching slot", { actor: combatant.actor?.name,
+          firstTurnReached: state.reactions.initialized, availableSlots: allReactionSlots(state.reactions).filter(slot => slot.remaining > 0).length });
+        return false;
+      }
       before.slotId = spent.slot.id; before.slot = spent.before;
       this.debug("Reaction slot spent", { actionSlug: event.actionSlug ?? event.slug, matchingSlots: spent.matches, spent: spent.slot.id });
     }
@@ -209,14 +218,31 @@ export class ActionTracker {
       if (["action", "free"].includes(event.resource) && !game.settings.get(MODULE_ID, "autoActions")) return;
       const combatant = this.findCombatant(event.actorId);
       if (combatant) {
+        if (event.source === "pf2e-reaction-strike" && this.consumeReactionStrikeIntent(event.actorId, event.actionSlug)) {
+          this.debug("Reaction strike roll deduplicated from reaction card", { actorId: event.actorId, actionSlug: event.actionSlug });
+          return;
+        }
         this.debug("Detected action", { label: event.label, actorId: event.actorId, cost: event.cost, confidence: event.confidence, messageId: message.id });
         const recorded = await this.recordLocal(combatant, { ...event, automatic: true });
+        if (recorded && event.source === "pf2e-reaction-card" && REACTION_STRIKE_SLUGS.has(event.actionSlug)) {
+          this.addReactionStrikeIntent(event.actorId, event.actionSlug);
+        }
         if (recorded && event.movement && event.resource === "action") {
           MovementIntent.add({ actorId: event.actorId, combatantId: combatant.id, slug: event.slug, cost: event.cost, identity: event.identity });
         }
       }
       return;
     }
+  }
+
+  static addReactionStrikeIntent(actorId, slug, now = Date.now()) {
+    this.reactionStrikeIntents.set(`${actorId}:${slug}`, now + 10000);
+  }
+
+  static consumeReactionStrikeIntent(actorId, slug, now = Date.now()) {
+    const key = `${actorId}:${slug}`; const expires = this.reactionStrikeIntents.get(key);
+    this.reactionStrikeIntents.delete(key);
+    return Number.isFinite(expires) && expires >= now;
   }
 
   static async adjustLocal(combatant, delta, identity) {

--- a/scripts/encounter/turn-assistant/detectors/activity-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/activity-detector.js
@@ -1,6 +1,6 @@
 import { PF2eAdapter } from "../../../integrations/pf2e.js";
 
-/** Detect only messages carrying both a PF2e roll context and an item with an explicit cost. */
+/** Detect executed PF2e rolls and unrolled item-use cards with a verified item origin. */
 export class ActivityDetector {
   static detect(message) {
     const context = PF2eAdapter.getMessageContext(message);
@@ -8,7 +8,18 @@ export class ActivityDetector {
     const actor = PF2eAdapter.resolveMessageActor(message);
     const item = PF2eAdapter.resolveMessageItem(message);
     const cost = PF2eAdapter.getActionCost(item);
-    if (!context || !actor || !item || !cost) return null;
+    if (!actor || !item || !cost) return null;
+
+    if (!context) {
+      if (cost.type !== "reaction" || !PF2eAdapter.isItemUsageMessage(message, item)) return null;
+      return {
+        actorId: actor.id, resource: "reaction", cost: 1,
+        label: item.name ?? "PF2e Reaction", confidence: "certain", identity: `message:${message.id}`,
+        slug: PF2eAdapter.getActivitySlug(item), actionSlug: PF2eAdapter.getActivitySlug(item),
+        actionUuid: item.uuid ?? null, sourceUuid: item.sourceId ?? item.flags?.core?.sourceId ?? null,
+        source: "pf2e-reaction-card",
+      };
+    }
 
     const type = String(context.type ?? "");
     if (type.includes("damage") || type.includes("healing")) return null;

--- a/scripts/encounter/turn-assistant/reaction/reaction-display.js
+++ b/scripts/encounter/turn-assistant/reaction/reaction-display.js
@@ -1,0 +1,33 @@
+import { ActionState } from "../action-state.js";
+import { PF2eAdapter } from "../../../integrations/pf2e.js";
+import { ReactionTracker } from "./reaction-tracker.js";
+import { allReactionSlots, generalSlot, REACTION_SCHEMA_VERSION } from "./reaction-state.js";
+
+function localize(key) { return game.i18n.localize(`PF2ETokenBar.TurnAssistant.Reactions.${key}`); }
+
+/** Read-only reaction presentation shared by active and inactive combatants. */
+export class ReactionDisplay {
+  static async render(combatant) {
+    if (!game.settings.get("pf2e-token-bar", "turnAssistant")) return null;
+    const stored = await ActionState.read(combatant);
+    const state = stored ?? { reactions: { version: REACTION_SCHEMA_VERSION, initialized: false, general: generalSlot(0), bonus: [] } };
+    ReactionTracker.reconcile(state, combatant.actor);
+
+    const root = document.createElement("div");
+    root.className = "pf2e-reaction-display";
+    for (const slot of allReactionSlots(state.reactions)) for (let i = 0; i < slot.max; i++) {
+      const unavailable = slot.refresh?.type === "start-own-turn" && !state.reactions.initialized;
+      const available = !unavailable && i < slot.remaining;
+      const element = document.createElement("span");
+      element.className = `reaction-slot ${unavailable ? "unavailable" : available ? "available" : "spent"}`;
+      const glyph = document.createElement("span"); glyph.className = "action-glyph";
+      glyph.textContent = PF2eAdapter.getActionGlyph("reaction"); element.append(glyph);
+      const restriction = slot.restriction?.type === "general" ? "" : `\n${slot.label}`;
+      const status = unavailable ? localize("FirstTurn") : available ? localize("Available") : localize("Spent");
+      const refresh = !unavailable && !available && slot.refresh?.type === "start-own-turn" ? `\n${localize("NextTurn")}` : "";
+      element.title = `${slot.label}${restriction}\n${status}${refresh}`;
+      root.append(element);
+    }
+    return root;
+  }
+}

--- a/scripts/encounter/turn-assistant/reaction/reaction-state.js
+++ b/scripts/encounter/turn-assistant/reaction/reaction-state.js
@@ -1,4 +1,4 @@
-export const REACTION_SCHEMA_VERSION = 2;
+export const REACTION_SCHEMA_VERSION = 3;
 
 export function generalSlot(remaining = 1) {
   return { id: "general", kind: "general", label: "General Reaction", max: 1, remaining,
@@ -7,11 +7,16 @@ export function generalSlot(remaining = 1) {
 
 export function migrateReactions(state) {
   if (state?.reactions?.version === REACTION_SCHEMA_VERSION) return state.reactions;
+  if (state?.reactions?.version === 2) {
+    state.reactions.version = REACTION_SCHEMA_VERSION;
+    // Version 2 flags only existed after a combatant's turn state was created.
+    state.reactions.initialized = true;
+    return state.reactions;
+  }
   const available = state?.reaction?.available;
-  const reactions = { version: REACTION_SCHEMA_VERSION, general: generalSlot(available === false ? 0 : 1), bonus: [] };
+  const reactions = { version: REACTION_SCHEMA_VERSION, initialized: true, general: generalSlot(available === false ? 0 : 1), bonus: [] };
   if (state) { state.reactions = reactions; delete state.reaction; }
   return reactions;
 }
 
 export function allReactionSlots(reactions) { return [reactions.general, ...(reactions.bonus ?? [])]; }
-

--- a/scripts/encounter/turn-assistant/reaction/reaction-tracker.js
+++ b/scripts/encounter/turn-assistant/reaction/reaction-tracker.js
@@ -8,7 +8,8 @@ export class ReactionTracker {
     const existing = new Map(reactions.bonus.map(slot => [slot.id, slot]));
     const permanent = ReactionSourceProvider.getSources(actor).map(source => {
       const old = existing.get(source.id);
-      return { ...source, max: source.amount, remaining: old ? Math.min(source.amount, old.remaining) : source.initialRemaining,
+      const gated = source.refresh === "start-own-turn" && !reactions.initialized;
+      return { ...source, max: source.amount, remaining: old ? Math.min(source.amount, old.remaining) : gated ? 0 : source.initialRemaining,
         refresh: { type: source.refresh }, expires: { type: source.expires }, restriction: structuredClone(source.restriction) };
     });
     const temporary = reactions.bonus.filter(slot => slot.kind === "temporary");
@@ -34,6 +35,7 @@ export class ReactionTracker {
 
   static refresh(state, type) {
     const reactions = migrateReactions(state);
+    if (type === "start-own-turn") reactions.initialized = true;
     for (const slot of allReactionSlots(reactions)) if (slot.refresh?.type === type) slot.remaining = slot.max;
     reactions.bonus = reactions.bonus.filter(slot => slot.expires?.type !== type);
   }

--- a/scripts/encounter/turn-assistant/turn-assistant.js
+++ b/scripts/encounter/turn-assistant/turn-assistant.js
@@ -3,7 +3,6 @@ import { ActionState } from "./action-state.js";
 import { ActionTracker } from "./action-tracker.js";
 import { TurnWarnings } from "./turn-warnings.js";
 import { MovementTracker } from "./movement-tracker.js";
-import { allReactionSlots } from "./reaction/reaction-state.js";
 
 const MODULE_ID = "pf2e-token-bar";
 
@@ -30,12 +29,7 @@ export class TurnAssistant {
     const actions = document.createElement("span"); actions.className = "pf2e-turn-actions";
     for (let i = 0; i < state.actions.remaining; i++) actions.append(glyph("action"));
     actions.title = game.i18n.format("PF2ETokenBar.TurnAssistant.ActionsRemaining", { count: state.actions.remaining }); resources.append(actions);
-    const reactions = document.createElement("span"); reactions.className = "pf2e-turn-reactions";
-    for (const slot of allReactionSlots(state.reactions)) for (let i = 0; i < slot.max; i++) {
-      const reaction = document.createElement("span"); reaction.className = "reaction-slot"; reaction.classList.toggle("spent", i >= slot.remaining);
-      reaction.append(glyph("reaction")); reaction.title = `${slot.label}\n${slot.restriction?.type ?? "general"}`; reactions.append(reaction);
-    }
-    resources.append(reactions); root.append(resources);
+    root.append(resources);
 
     if (state.reasons?.some(reason => reason.type === "quickened")) {
       const quickened = document.createElement("div"); quickened.className = "pf2e-turn-economy";

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -59,6 +59,18 @@ export class PF2eAdapter {
     return message?.flags?.pf2e?.context ?? null;
   }
 
+  /** PF2e V14 item.toMessage/createUseActionMessage cards carry an item origin, even without a roll context. */
+  static isItemUsageMessage(message, item) {
+    const origin = message?.flags?.pf2e?.origin;
+    if (!origin || !item || message?.item !== item) return false;
+    const actor = this.resolveMessageActor(message);
+    if (!actor || (item.actor && item.actor.id !== actor.id)) return false;
+    const uuidMatches = typeof origin.uuid === "string" && origin.uuid === item.uuid;
+    const sourceId = item.sourceId ?? item.flags?.core?.sourceId;
+    const sourceMatches = typeof origin.sourceId === "string" && origin.sourceId === sourceId;
+    return uuidMatches || sourceMatches;
+  }
+
   /** Resolve a unique supported action from PF2e's sorted check roll options. */
   static getMessageActionSlug(message) {
     const options = this.getMessageContext(message)?.options;

--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -5,6 +5,7 @@ import { PointsTrackerIntegration, QuestLogIntegration } from "./integrations/op
 import { TokenProvider } from "./token-bar/token-provider.js";
 import { ModuleDialog } from "./ui/dialogs.js";
 import { TurnAssistant } from "./encounter/turn-assistant/turn-assistant.js";
+import { ReactionDisplay } from "./encounter/turn-assistant/reaction/reaction-display.js";
 
 Hooks.once("init", () => {
   game.settings.register("pf2e-token-bar", "position", {
@@ -856,6 +857,10 @@ class PF2ETokenBar {
       }
       wrapper.appendChild(effectBar);
 
+      if (combatant) {
+        const reactionDisplay = await ReactionDisplay.render(combatant);
+        if (reactionDisplay) wrapper.appendChild(reactionDisplay);
+      }
       if (combatant?.id === activeCombat?.combatant?.id) {
         const assistant = await TurnAssistant.render(combatant);
         if (assistant) wrapper.appendChild(assistant);

--- a/styles/token-bar.css
+++ b/styles/token-bar.css
@@ -469,6 +469,9 @@
 #pf2e-token-bar .pf2e-turn-reactions { display: inline-flex; gap: .1rem; }
 #pf2e-token-bar .reaction-slot { display: inline-flex; }
 #pf2e-token-bar .reaction-slot.spent { opacity: .3; filter: grayscale(1); }
+#pf2e-token-bar .pf2e-reaction-display { display: flex; justify-content: center; gap: 2px; margin-top: 4px; }
+#pf2e-token-bar .reaction-slot.available { opacity: 1; }
+#pf2e-token-bar .reaction-slot.unavailable { opacity: .18; filter: grayscale(1); }
 #pf2e-token-bar .pf2e-turn-controls button { min-width: 26px; height: 24px; padding: 2px 4px; }
 #pf2e-token-bar .pf2e-turn-controls button .action-glyph { font-size: 1rem; }
 #pf2e-token-bar .pf2e-turn-last { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 3px; }

--- a/tests/turn-assistant.test.mjs
+++ b/tests/turn-assistant.test.mjs
@@ -73,6 +73,9 @@ const { ReactionTracker } = await import("../scripts/encounter/turn-assistant/re
 const { StrikeDetector } = await import("../scripts/encounter/turn-assistant/detectors/strike-detector.js");
 const { ReactionSourceProvider } = await import("../scripts/encounter/turn-assistant/reaction/reaction-source-provider.js");
 const { generalSlot } = await import("../scripts/encounter/turn-assistant/reaction/reaction-state.js");
+const { ActivityDetector } = await import("../scripts/encounter/turn-assistant/detectors/activity-detector.js");
+const { ActionState } = await import("../scripts/encounter/turn-assistant/action-state.js");
+const { ActionTracker } = await import("../scripts/encounter/turn-assistant/action-tracker.js");
 
 function reactionState(slugs = []) {
   const actor = { items: slugs.map((slug, i) => ({ id: `i${i}`, slug })) };
@@ -122,6 +125,61 @@ test("reaction refresh is source-specific and temporary expiration is supported"
   assert.equal(state.reactions.bonus[0].remaining, 0);
   ReactionTracker.refresh(state, "end-current-turn"); assert.equal(state.reactions.bonus.some(s => s.id === "enemy"), false);
   ReactionTracker.refresh(state, "start-own-turn"); assert.equal(state.reactions.bonus[0].remaining, 1);
+});
+
+test("first-turn gate distinguishes unavailable, initialized, and spent", () => {
+  const combatant = { id: "c", actorId: "a", combat: { id: "combat", round: 1, turn: 1 } };
+  const state = ActionState.create(combatant, 3, null, { reactionsInitialized: false });
+  assert.equal(state.reactions.initialized, false);
+  assert.equal(state.reactions.general.remaining, 0);
+  ReactionTracker.reconcile(state, { items: [{ id: "q", slug: "quick-shield-block" }] });
+  assert.equal(state.reactions.bonus[0].remaining, 0);
+  assert.equal(ReactionTracker.spend(state, { actionSlug: "shield-block" }), null);
+  assert.equal(state.reactions.initialized, false, "attempted use must not initialize reactions");
+  ReactionTracker.refresh(state, "start-own-turn");
+  assert.equal(state.reactions.initialized, true);
+  assert.deepEqual([state.reactions.general.remaining, state.reactions.bonus[0].remaining], [1, 1]);
+  ReactionTracker.spend(state, { actionSlug: "shield-block" });
+  assert.deepEqual([state.reactions.general.remaining, state.reactions.bonus[0].remaining], [1, 0]);
+  ReactionTracker.refresh(state, "start-own-turn");
+  assert.deepEqual([state.reactions.general.remaining, state.reactions.bonus[0].remaining], [1, 1]);
+});
+
+function reactionCard(slug, { id = slug, context = false, origin = true } = {}) {
+  const actor = { id: "reactor" };
+  const item = { id: `item-${slug}`, name: slug, slug, actor, uuid: `Actor.reactor.Item.${slug}`,
+    sourceId: `Compendium.pf2e.actionspf2e.Item.${slug}`, actionCost: { type: "reaction", value: 1 } };
+  return { id, actor, item, flags: { pf2e: {
+    ...(context ? { context: { type: "roll" } } : {}),
+    ...(origin ? { origin: { uuid: item.uuid, sourceId: item.sourceId, type: "feat" } } : {}),
+  } } };
+}
+
+test("Shield Block and Reactive Strike item-use cards need no PF2e context", () => {
+  for (const slug of ["shield-block", "reactive-strike"]) {
+    const event = ActivityDetector.detect(reactionCard(slug));
+    assert.equal(event.resource, "reaction");
+    assert.equal(event.actionSlug, slug);
+    assert.equal(event.source, "pf2e-reaction-card");
+  }
+});
+
+test("reaction cards require a matching PF2e item origin and ignore rerolls", () => {
+  assert.equal(ActivityDetector.detect(reactionCard("shield-block", { origin: false })), null);
+  const mismatch = reactionCard("shield-block"); mismatch.flags.pf2e.origin.uuid = "Actor.other.Item.other";
+  mismatch.flags.pf2e.origin.sourceId = "Compendium.other";
+  assert.equal(ActivityDetector.detect(mismatch), null);
+  const reroll = reactionCard("shield-block"); reroll.isReroll = true;
+  assert.equal(ActivityDetector.detect(reroll), null);
+});
+
+test("reaction strike intent suppresses exactly one correlated strike roll", () => {
+  ActionTracker.reactionStrikeIntents.clear();
+  ActionTracker.addReactionStrikeIntent("reactor", "reactive-strike", 100);
+  assert.equal(ActionTracker.consumeReactionStrikeIntent("reactor", "reactive-strike", 101), true);
+  assert.equal(ActionTracker.consumeReactionStrikeIntent("reactor", "reactive-strike", 102), false);
+  ActionTracker.addReactionStrikeIntent("reactor", "reactive-strike", 100);
+  assert.equal(ActionTracker.consumeReactionStrikeIntent("reactor", "reactive-strike", 10101), false);
 });
 
 test("reaction strike detector prevents normal action charging and rerolls", () => {


### PR DESCRIPTION
### Motivation

- Surface each combatant's reaction slots at all times and preserve the existing "first own turn" gate so reactions are not granted before a combatant's first turn. 
- Make PF2e Action-Tab reaction cards (e.g. `Shield Block`, `Reactive Strike`) count as reaction usage even when `flags.pf2e.context` is absent, while avoiding false positives and keeping the existing slot/undo architecture.

### Description

- Add explicit `initialized` flag to the reaction schema and bump the schema version to `3`, so the state distinguishes `not-yet-initialized` from `initialized` but `remaining === 0` (file: `scripts/encounter/turn-assistant/reaction/reaction-state.js`).
- Preserve the first-turn gate by creating states with `initialized: false` pre-first-turn and keeping `start-own-turn` gated sources at `remaining: 0` until `start-own-turn` refresh runs (files: `scripts/encounter/turn-assistant/action-state.js`, `scripts/encounter/turn-assistant/reaction/reaction-tracker.js`).
- Add `ReactionDisplay` read-only UI component that renders every combatant's reaction slots with the PF2e `R` glyph and three visual states `available`, `spent`, `unavailable` and localized tooltips (file: `scripts/encounter/turn-assistant/reaction/reaction-display.js`, style updates in `styles/token-bar.css`).
- Remove duplicate reaction rendering from `TurnAssistant.render()` and render `ReactionDisplay` per-combatant in the token bar so actions remain shown only for the active combatant (files: `scripts/encounter/turn-assistant/turn-assistant.js`, `scripts/token-bar.js`).
- Extend the PF2e adapter with `isItemUsageMessage(message, item)` which verifies message origin against the item `uuid` or `sourceId`, and update `ActivityDetector` so item-use cards with `actionCost.type === 'reaction'` are counted as reaction usage even if `flags.pf2e.context` is missing, provided the message carries a verifiable origin (files: `scripts/integrations/pf2e.js`, `scripts/encounter/turn-assistant/detectors/activity-detector.js`).
- Prefer specific/restricted bonus slots (e.g. Quick Shield Block, Tactical Reflexes, implement-restricted slots) via the existing matcher; leave selection logic and registry intact (files: `scripts/encounter/turn-assistant/reaction/reaction-matcher.js`, `scripts/encounter/turn-assistant/reaction/reaction-registry.js`).
- Add short-lived Reaction-Strike intent bookkeeping to deduplicate a Reaction-Card consumption and the subsequent weapon `attack-roll` so a Reactive Strike does not also consume a normal action (file: `scripts/encounter/turn-assistant/action-tracker.js`).
- Add debug traces describing: first-turn initialization events, attempted reaction spends when no slot matches, matched slot list and the actually spent slot, and Reaction-Strike deduplication decisions (file: `scripts/encounter/turn-assistant/action-tracker.js`).
- Localization strings added for the new reaction UI states in `lang/en.json` and `lang/de.json`.

### Testing

- Ran the unit/integration test suite: `node --test tests/turn-assistant.test.mjs` — all tests passed (12/12).
- Per-file JavaScript syntax checks: `find scripts -name "*.js" -print0 | xargs -0 -n1 node --check` — no syntax errors.
- JSON localization validation: `python -m json.tool lang/en.json` and `python -m json.tool lang/de.json` — valid JSON.
- Additional checks: `git diff --check` and repository grep for `reference/pf2e` usage to confirm reference is documented-only (no runtime imports) — OK.

Notes/known limitation: the Reactive-Strike correlation uses actor ID + action-slug with a short TTL because PF2e does not provide a stable shared message ID between an Ability-card post and a later attack roll; this approach avoids parsing localized chat content while still reliably deduplicating the common card->strike flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b2d74b8908327a4385ef406f74ebb)