### PR TITLE
Automate Stand action cost on Prone removal with Kip Up exemption

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -233,6 +233,8 @@
       "Undo": "Rückgängig",
       "EndTurn": "Zug beenden",
       "Movement": "Bewegung",
+      "Stand": "Aufstehen",
+      "KipUp": "Aufspringen",
       "Quickened": "Beschleunigt (die zusätzliche Aktion kann Einschränkungen haben)"
     }
   }

--- a/lang/en.json
+++ b/lang/en.json
@@ -233,6 +233,8 @@
       "Undo": "Undo",
       "EndTurn": "End Turn",
       "Movement": "Movement",
+      "Stand": "Stand",
+      "KipUp": "Kip Up",
       "Quickened": "Quickened (the extra action may have usage restrictions)"
     }
   }

--- a/scripts/encounter/turn-assistant/prone-tracker.js
+++ b/scripts/encounter/turn-assistant/prone-tracker.js
@@ -1,0 +1,46 @@
+import { PF2eAdapter } from "../../integrations/pf2e.js";
+import { ActionTracker } from "./action-tracker.js";
+
+const MODULE_ID = "pf2e-token-bar";
+
+/** Charges Stand when PF2e removes the active combatant's embedded prone condition. */
+export class ProneTracker {
+  static registerHooks() {
+    Hooks.on("deleteItem", (item, operation, userId) => this.onDeleteItem(item, operation, userId));
+  }
+
+  static async onDeleteItem(item, operation = {}, _userId = null) {
+    if (item?.type !== "condition" || PF2eAdapter.getActivitySlug(item) !== "prone") return false;
+    if (!game.settings.get(MODULE_ID, "turnAssistant") || !game.settings.get(MODULE_ID, "autoActions")) return false;
+    if (!ActionTracker.isAuthority() || game.paused) return false;
+
+    const combat = game.combat;
+    const actor = item.actor ?? item.parent;
+    const active = combat?.combatant;
+    if (!combat?.started) return this.ignore(actor, false, "no active encounter");
+    const isActive = !!actor && !!active && (active.actor === actor || active.actorId === actor.id);
+    if (!isActive) return this.ignore(actor, false, "actor is not active combatant");
+
+    const kipUp = PF2eAdapter.hasKipUp(actor);
+    if (kipUp) {
+      ActionTracker.debug("Prone removed", { actor: actor.name, combatantActive: true, kipUp: true, decision: "Kip Up", cost: 0 });
+      return false;
+    }
+
+    const identity = `prone-removed:${combat.id}:${combat.round ?? 0}:${combat.turn ?? 0}:${active.id}:${item.id}`;
+    ActionTracker.debug("Prone removed", { actor: actor.name, combatantActive: true, kipUp: false, decision: "Stand", cost: 1 });
+    return ActionTracker.recordLocal(active, {
+      resource: "action",
+      cost: 1,
+      label: game.i18n.localize("PF2ETokenBar.TurnAssistant.Stand"),
+      identity,
+      automatic: true,
+      source: "prone-removed",
+    });
+  }
+
+  static ignore(actor, active, reason) {
+    ActionTracker.debug("Prone removed", { actor: actor?.name, combatantActive: active, decision: "ignored", reason });
+    return false;
+  }
+}

--- a/scripts/encounter/turn-assistant/turn-assistant.js
+++ b/scripts/encounter/turn-assistant/turn-assistant.js
@@ -3,6 +3,7 @@ import { ActionState } from "./action-state.js";
 import { ActionTracker } from "./action-tracker.js";
 import { TurnWarnings } from "./turn-warnings.js";
 import { MovementTracker } from "./movement-tracker.js";
+import { ProneTracker } from "./prone-tracker.js";
 
 const MODULE_ID = "pf2e-token-bar";
 
@@ -58,6 +59,7 @@ export class TurnAssistant {
     ActionTracker.onChange = render;
     ActionTracker.registerSocket();
     MovementTracker.registerHooks();
+    ProneTracker.registerHooks();
     Hooks.on("createChatMessage", message => ActionTracker.processMessage(message));
     Hooks.on("updateCombat", async combat => { if (combat.id === game.combat?.id && combat.started) { await ActionTracker.advanceReactionTurn(combat); await ActionTracker.startTurn(combat.combatant); } });
     Hooks.on("combatStart", combat => ActionTracker.startTurn(combat.combatant));

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -9,6 +9,8 @@ function warnOnce(api) {
 
 /** The deliberately small boundary around PF2e's public, version-sensitive APIs. */
 export class PF2eAdapter {
+  static KIP_UP_SLUG = "kip-up";
+  static KIP_UP_SOURCE_ID = "Compendium.pf2e.feats-srd.Item.gBSPbQRXdagZTUwY";
   static MOVEMENT_ACTION_SLUGS = new Set(["stride", "step", "climb", "swim", "crawl", "sneak", "leap", "high-jump", "long-jump", "fly"]);
   // PF2e 7.8 (Foundry V14) SystemActions definitions. Used only if the public
   // game.pf2e.actions collection is unavailable or does not contain the action.
@@ -39,6 +41,17 @@ export class PF2eAdapter {
 
   static getActivitySlug(item) {
     return item?.slug ?? item?.system?.slug ?? null;
+  }
+
+  static hasFeat(actor, slug, sourceId = null) {
+    return actor?.items?.some?.(item => item?.type === "feat" && (
+      this.getActivitySlug(item) === slug
+      || (sourceId && (item.sourceId ?? item.flags?.core?.sourceId ?? item._stats?.compendiumSource) === sourceId)
+    )) ?? false;
+  }
+
+  static hasKipUp(actor) {
+    return this.hasFeat(actor, this.KIP_UP_SLUG, this.KIP_UP_SOURCE_ID);
   }
 
   static isMovementActivity(item) {

--- a/tests/turn-assistant.test.mjs
+++ b/tests/turn-assistant.test.mjs
@@ -1,10 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+const settingValues = new Map();
 globalThis.game = {
   pf2e: { actions: new Map() },
   i18n: { localize: value => value },
-  settings: { get: () => false },
+  settings: { get: (_module, key) => settingValues.get(key) ?? false },
   actors: new Map(),
 };
 
@@ -76,6 +77,7 @@ const { generalSlot } = await import("../scripts/encounter/turn-assistant/reacti
 const { ActivityDetector } = await import("../scripts/encounter/turn-assistant/detectors/activity-detector.js");
 const { ActionState } = await import("../scripts/encounter/turn-assistant/action-state.js");
 const { ActionTracker } = await import("../scripts/encounter/turn-assistant/action-tracker.js");
+const { ProneTracker } = await import("../scripts/encounter/turn-assistant/prone-tracker.js");
 
 function reactionState(slugs = []) {
   const actor = { items: slugs.map((slug, i) => ({ id: `i${i}`, slug })) };
@@ -188,4 +190,55 @@ test("reaction strike detector prevents normal action charging and rerolls", () 
   const event = StrikeDetector.detect(reactive);
   assert.equal(event.resource, "reaction"); assert.equal(event.cost, 1);
   reactive.flags.pf2e.context.isReroll = true; assert.equal(StrikeDetector.detect(reactive), null);
+});
+
+test("Kip Up detection uses the verified feat slug or source, never its localized name", () => {
+  assert.equal(PF2eAdapter.hasKipUp({ items: [{ type: "feat", slug: "kip-up", name: "Aufspringen" }] }), true);
+  assert.equal(PF2eAdapter.hasKipUp({ items: [{ type: "feat", slug: "other", name: "Kip Up" }] }), false);
+  assert.equal(PF2eAdapter.hasKipUp({ items: [{ type: "feat", slug: "renamed", sourceId: PF2eAdapter.KIP_UP_SOURCE_ID }] }), true);
+});
+
+test("prone removal charges only the active combatant, supports Kip Up, overspend, dedupe, and undo", async () => {
+  settingValues.set("turnAssistant", true); settingValues.set("autoActions", true);
+  game.user = { id: "gm" };
+  game.users = [{ id: "gm", active: true, isGM: true }];
+  game.paused = false;
+
+  const actor = { id: "actor", name: "Valeros", items: [] };
+  let state;
+  const combatant = {
+    id: "combatant", actorId: actor.id, actor,
+    combat: { id: "combat", round: 2, turn: 1 },
+    getFlag: async () => state,
+    setFlag: async (_module, _key, value) => { state = structuredClone(value); },
+  };
+  game.combat = { id: "combat", round: 2, turn: 1, started: true, combatant };
+  state = ActionState.create(combatant, 3);
+  const prone = { id: "prone-id", type: "condition", slug: "prone", actor };
+
+  assert.equal(await ProneTracker.onDeleteItem({ ...prone, slug: "frightened" }), false);
+  assert.equal(await ProneTracker.onDeleteItem(prone), true);
+  assert.equal(state.actions.remaining, 2);
+  assert.equal(state.history.at(-1).source, "prone-removed");
+  assert.equal(state.history.at(-1).label, "PF2ETokenBar.TurnAssistant.Stand");
+  assert.equal(await ProneTracker.onDeleteItem(prone), false, "the deterministic identity deduplicates a repeated hook/signal");
+  assert.equal(state.actions.remaining, 2);
+  await ActionTracker.undoLocal(combatant); assert.equal(state.actions.remaining, 3);
+
+  actor.items = [{ type: "feat", slug: "kip-up" }];
+  assert.equal(await ProneTracker.onDeleteItem({ ...prone, id: "kip" }), false);
+  assert.equal(state.actions.remaining, 3);
+
+  actor.items = [];
+  game.combat.combatant = { ...combatant, actorId: "other", actor: { id: "other" } };
+  assert.equal(await ProneTracker.onDeleteItem({ ...prone, id: "inactive" }), false);
+  assert.equal(state.actions.remaining, 3);
+
+  game.combat.combatant = combatant; state.actions.remaining = 0;
+  assert.equal(await ProneTracker.onDeleteItem({ ...prone, id: "overspend" }), true);
+  assert.equal(state.actions.remaining, 0); assert.equal(state.overSpent, true);
+
+  game.combat.started = false;
+  assert.equal(await ProneTracker.onDeleteItem({ ...prone, id: "cleanup" }), false);
+  settingValues.clear();
 });


### PR DESCRIPTION
### Motivation
- Automatically interpret the removal of the PF2e `prone` condition as a `Stand` and charge the active combatant 1 action while keeping existing Action/Reaction/Movement, Authority, History and Undo systems unchanged.
- Respect PF2e V14 canonical data for `prone`, `stand`, and the `kip-up` feat (slug/source), and avoid runtime imports from `reference/pf2e` or localized name checks.
- Only trigger on authoritative clients for the active combatant during an active encounter and avoid double-booking when the system action detector already records `stand`.
- Provide a small, focused tracker class for condition-based detection rather than expanding chat/message detectors.

### Description
- Added a new `ProneTracker` at `scripts/encounter/turn-assistant/prone-tracker.js` that listens to Foundry V14's `deleteItem` hook and reacts only to condition items with slug `prone` to apply the `Stand` cost when appropriate. 
- Extended `PF2eAdapter` (`scripts/integrations/pf2e.js`) with `hasFeat`, `hasKipUp`, `KIP_UP_SLUG`, and `KIP_UP_SOURCE_ID` to reliably detect the `kip-up` feat by slug or compendium source, never by localized name. 
- Integrated the tracker by registering it from `TurnAssistant.registerHooks()` (`scripts/encounter/turn-assistant/turn-assistant.js`) so existing socket/authority and movement/reaction systems remain untouched. 
- Use the existing `ActionTracker.recordLocal` API to record a single action spend with `source:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d61c330288327b7a23b7848dc388b)