### PR TITLE
Prevent concurrent token-bar render duplicates (generation guard + atomic commit)

### DIFF
--- a/scripts/token-bar.js
+++ b/scripts/token-bar.js
@@ -155,10 +155,25 @@ Hooks.once("init", () => {
   });
 });
 
-class PF2ETokenBar {
+export class PF2ETokenBar {
   static hoveredToken = null;
   static zeroHpAttackers = new Map();
   static zeroHpPreviousHp = new Map();
+  static renderGeneration = 0;
+
+  static removeAllBars(root = document) {
+    root.querySelectorAll("#pf2e-token-bar").forEach(element => element.remove());
+  }
+
+  static commitRender(generation, bar, root = document) {
+    if (generation !== this.renderGeneration) return false;
+
+    // Keep this replacement synchronous: no render can supersede this one
+    // between the generation check and the DOM commit.
+    this.removeAllBars(root);
+    root.body.appendChild(bar);
+    return true;
+  }
 
   static debug(...args) {
     if (game.settings.get("pf2e-token-bar", "debug")) console.debug(...args);
@@ -423,10 +438,11 @@ class PF2ETokenBar {
   }
 
   static async render() {
+    const generation = ++this.renderGeneration;
     PF2ERingMenu.close();
     if (!canvas?.ready) return;
     if (!game.settings.get("pf2e-token-bar", "enabled")) {
-      document.getElementById("pf2e-token-bar")?.remove();
+      this.removeAllBars();
       return;
     }
 
@@ -453,9 +469,7 @@ class PF2ETokenBar {
 
     this.debug("PF2ETokenBar | found tokens", tokens.map(t => t.id));
     if (!tokens.length) return;
-    let bar = document.getElementById("pf2e-token-bar");
-    if (bar) bar.remove();
-    bar = document.createElement("div");
+    const bar = document.createElement("div");
     bar.id = "pf2e-token-bar";
     const scale = game.settings.get("pf2e-token-bar", "scale");
     bar.style.transform = `scale(${scale})`;
@@ -859,10 +873,12 @@ class PF2ETokenBar {
 
       if (combatant) {
         const reactionDisplay = await ReactionDisplay.render(combatant);
+        if (generation !== this.renderGeneration) return;
         if (reactionDisplay) wrapper.appendChild(reactionDisplay);
       }
       if (combatant?.id === activeCombat?.combatant?.id) {
         const assistant = await TurnAssistant.render(combatant);
+        if (generation !== this.renderGeneration) return;
         if (assistant) wrapper.appendChild(assistant);
       }
 
@@ -1205,7 +1221,7 @@ class PF2ETokenBar {
       document.addEventListener("mouseup", onMouseUp);
     });
 
-    document.body.appendChild(bar);
+    if (!this.commitRender(generation, bar)) return;
     this.scrollActiveToken("instant");
   }
 

--- a/tests/token-bar-render.test.mjs
+++ b/tests/token-bar-render.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+globalThis.Hooks = {
+  once: () => {},
+  on: () => {},
+};
+globalThis.window = { addEventListener: () => {} };
+globalThis.document = {
+  querySelectorAll: () => [],
+  body: { appendChild: () => {} },
+};
+globalThis.canvas = { ready: true };
+globalThis.game = {
+  settings: { get: (_module, key) => key !== "enabled" },
+};
+
+const { PF2ETokenBar } = await import("../scripts/token-bar.js");
+
+function renderDocument(initialBars = []) {
+  const bars = [...initialBars];
+  return {
+    bars,
+    querySelectorAll(selector) {
+      assert.equal(selector, "#pf2e-token-bar");
+      return [...bars];
+    },
+    body: {
+      appendChild(element) {
+        bars.push(element);
+      },
+    },
+  };
+}
+
+function bar(label) {
+  return {
+    label,
+    remove() {
+      const index = this.owner.bars.indexOf(this);
+      if (index >= 0) this.owner.bars.splice(index, 1);
+    },
+  };
+}
+
+function addBars(root, labels) {
+  for (const label of labels) {
+    const element = bar(label);
+    element.owner = root;
+    root.bars.push(element);
+  }
+}
+
+test("latest concurrent render wins and a stale render cannot commit", () => {
+  const root = renderDocument();
+  const older = bar("older");
+  const newer = bar("newer");
+  older.owner = newer.owner = root;
+
+  const generationA = ++PF2ETokenBar.renderGeneration;
+  const generationB = ++PF2ETokenBar.renderGeneration;
+
+  assert.equal(PF2ETokenBar.commitRender(generationB, newer, root), true);
+  assert.equal(PF2ETokenBar.commitRender(generationA, older, root), false);
+  assert.deepEqual(root.bars.map(element => element.label), ["newer"]);
+});
+
+test("a successful render removes every pre-existing duplicate bar", () => {
+  const root = renderDocument();
+  addBars(root, ["old-1", "old-2", "old-3"]);
+  const newest = bar("newest");
+  newest.owner = root;
+  const generation = ++PF2ETokenBar.renderGeneration;
+
+  assert.equal(PF2ETokenBar.commitRender(generation, newest, root), true);
+  assert.deepEqual(root.bars.map(element => element.label), ["newest"]);
+});
+
+test("disabled rendering removes every pre-existing duplicate bar", async () => {
+  const root = renderDocument();
+  addBars(root, ["old-1", "old-2", "old-3"]);
+  globalThis.document = root;
+  game.settings.get = (_module, key) => key === "enabled" ? false : false;
+
+  await PF2ETokenBar.render();
+
+  assert.equal(root.bars.length, 0);
+});


### PR DESCRIPTION
### Motivation

- Fix a race where multiple nearly-simultaneous `PF2ETokenBar.render()` runs could create multiple DOM elements with the same ID `#pf2e-token-bar` on one client. 
- Keep existing UI, behavior and external logic (ReactionDisplay / TurnAssistant / action/reaction state) unchanged while making rendering robust under heavy hook traffic.

### Description

- Introduce a monotonic `renderGeneration` counter and capture `const generation = ++this.renderGeneration` at each `render()` start so that only the newest render may commit its DOM changes. 
- Build the new bar detached (do not remove the existing bar at the start) and check `generation !== this.renderGeneration` after heavy `await` points (`ReactionDisplay.render` and `TurnAssistant.render`) to silently abort stale builds. 
- Add `removeAllBars()` (uses `querySelectorAll("#pf2e-token-bar")`) and `commitRender(generation, bar)` which atomically removes all duplicates and appends the new bar synchronously with no `await` between generation-check and DOM mutation. 
- Replace initial `getElementById(...).remove()` usage with `removeAllBars()` and keep scroll behavior (`scrollActiveToken`) executed only after a successful commit; no global listener registrations were moved into per-render scope.

### Testing

- Ran the unit test suite with `node --test tests/*.test.mjs` and all tests passed (TAP output: 17 tests ok), including the new concurrent render / duplicate-cleanup / disabled-render tests. 
- Added `tests/token-bar-render.test.mjs` covering (1) stale concurrent render cannot commit, (2) successful render removes pre-existing duplicates, and (3) disabled rendering removes all bars. 
- Per-file JavaScript syntax checks (`node --check` on `scripts/*.js`) and repository diff checks completed without errors. 
- Note: an interactive multi-client Foundry V14 acceptance run could not be performed in the non-interactive CI environment, but the new unit tests deterministically cover the targeted race scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e08c8a17883278f44e0a71e2e5869)