### PR TITLE
Improve PF2e chat action detection and distance-based movement costing

### DIFF
--- a/docs/action-movement-tracking.md
+++ b/docs/action-movement-tracking.md
@@ -1,0 +1,55 @@
+# PF2e V14 chat action and movement tracking
+
+## Verified PF2e data
+
+The implementation was checked against these files in the local `reference/pf2e` checkout:
+
+- `src/module/chat-message/data.ts` (`flags.pf2e.origin`, check contexts, options, traits, and reroll context)
+- `src/module/chat-message/helpers.ts` (item-use messages and action glyphs)
+- `src/module/item/ability/document.ts` and `src/module/item/feat/document.ts` (`actionCost`)
+- `src/module/item/ability/helpers.ts` (action type/cost roll options)
+- `src/module/actor/creature/document.ts`, `src/module/actor/creature/types.ts`, and
+  `src/module/system/statistic/speed.ts` (derived `actor.movement.speeds[type].value`)
+- `src/module/canvas/token/ruler.ts` (PF2e's distance/cost handling)
+
+Reliable runtime inputs are `message.actor`, `message.item`, `flags.pf2e.origin.uuid`,
+`flags.pf2e.context` (including `type`, `options`, and `traits`), item `actionCost`,
+item `slug`/`uuid`/`sourceId`, and structured `action:*` roll options. No visible or
+localized chat HTML is inspected. A text-only third-party card is deliberately ignored.
+
+## Detection pipeline
+
+The authority processes each message in this priority order: Strike, item-less PF2e
+SystemAction, then generic PF2e Activity. Rerolls are rejected first. Detector processing
+stops after the first match, and every event uses `message:<id>` for persisted idempotency.
+Reaction strikes and reaction cards remain reaction events; free actions cost zero.
+Generic item activities require an actor, item, supported action cost, and either an
+executed structured context or a matching PF2e item origin. This supports compatible
+third-party modules without identifying the originating UI or module. Damage/healing
+follow-ups, ambiguous roll options, unverifiable text-only cards, and `stand` are ignored.
+`stand` remains exclusively owned by `ProneTracker`.
+
+## Movement accounting
+
+Distance-based movement applies to `stride -> land`, `sneak -> land`, `fly -> fly`,
+`climb -> climb`, and `swim -> swim`. `step`, `crawl`, `leap`, `high-jump`, and
+`long-jump` retain their verified fixed PF2e action costs; they are not divided by land
+speed. A movement chat card creates a typed intent. Continuous movement consumes the
+unpaid intent and charges the measured session, while a fixed, already-paid movement
+intent suppresses the following token-movement charge. An unpaid intent with no token
+movement expires without synthesizing a movement session.
+
+Each `updateToken` segment is measured between the pre-update and post-update token
+centers with Foundry V14 `canvas.grid.measurePath`, then added to the debounced session.
+This preserves scene units, configured diagonal rules, turns in the route, and elevation
+handling supplied by Foundry's path API. At finalization the current derived speed is read
+without a global cache and the cost is `ceil(totalDistance / effectiveSpeed)`. A positive
+distance always costs at least one action, exact speed boundaries do not round upward,
+and costs above three remain a single history entry. Existing state clamping, overspend,
+and undo therefore apply to the full detected cost.
+
+If a requested fly/climb/swim speed is absent, the session is conservatively ignored and
+debug logging explains why; land is the default when there is no intent. PF2e/Foundry do
+not expose terrain-adjusted cost on ordinary token document updates, so this tracker does
+not pretend to infer difficult terrain. Forced-movement ambiguity likewise remains
+subject to the existing active-combatant, paused-game, authority, and GM-movement guards.

--- a/lang/de.json
+++ b/lang/de.json
@@ -100,7 +100,7 @@
         },
         "AutomaticMovementTracking": {
           "Name": "Automatisches Token-Movement-Tracking aktivieren",
-          "Hint": "Verbraucht eine Aktion, nachdem der aktive Kampfteilnehmer eine zusammenhängende Tokenbewegung beendet hat."
+          "Hint": "Verbraucht Aktionen anhand der Distanz einer zusammenhängenden Tokenbewegung und der aktuellen Bewegungsrate."
         },
         "OnlyTrackActiveCombatant": {
           "Name": "Nur aktiven Kampfteilnehmer tracken",
@@ -233,6 +233,8 @@
       "Undo": "Rückgängig",
       "EndTurn": "Zug beenden",
       "Movement": "Bewegung",
+      "DistanceUnits": "Fuß",
+      "MovementType": { "land": "Bewegung", "fly": "Fliegen", "climb": "Klettern", "swim": "Schwimmen" },
       "Stand": "Aufstehen",
       "KipUp": "Aufspringen",
       "Quickened": "Beschleunigt (die zusätzliche Aktion kann Einschränkungen haben)"

--- a/lang/en.json
+++ b/lang/en.json
@@ -100,7 +100,7 @@
         },
         "AutomaticMovementTracking": {
           "Name": "Enable Automatic Token Movement Tracking",
-          "Hint": "Spend one action after the active combatant completes a continuous token movement."
+          "Hint": "Spend actions from the active combatant based on continuous token-movement distance and current speed."
         },
         "OnlyTrackActiveCombatant": {
           "Name": "Only Track Active Combatant",
@@ -233,6 +233,8 @@
       "Undo": "Undo",
       "EndTurn": "End Turn",
       "Movement": "Movement",
+      "DistanceUnits": "ft",
+      "MovementType": { "land": "Move", "fly": "Fly", "climb": "Climb", "swim": "Swim" },
       "Stand": "Stand",
       "KipUp": "Kip Up",
       "Quickened": "Quickened (the extra action may have usage restrictions)"

--- a/scripts/encounter/turn-assistant/action-tracker.js
+++ b/scripts/encounter/turn-assistant/action-tracker.js
@@ -222,13 +222,22 @@ export class ActionTracker {
           this.debug("Reaction strike roll deduplicated from reaction card", { actorId: event.actorId, actionSlug: event.actionSlug });
           return;
         }
-        this.debug("Detected action", { label: event.label, actorId: event.actorId, cost: event.cost, confidence: event.confidence, messageId: message.id });
+        const movementType = event.movement ? PF2eAdapter.getMovementType(event.slug) : null;
+        if (movementType) {
+          MovementIntent.add({ actorId: event.actorId, combatantId: combatant.id, slug: event.slug,
+            movementType, cost: event.cost, identity: event.identity, paid: false });
+          this.debug("Chat movement intent detected", { actor: combatant.actor?.name, slug: event.slug, movementType, messageId: message.id });
+          return;
+        }
+        this.debug("Chat action detected", { actor: combatant.actor?.name, slug: event.slug, cost: event.cost,
+          source: event.source, contextPresent: !!PF2eAdapter.getMessageContext(message), decision: `spend ${event.cost}` });
         const recorded = await this.recordLocal(combatant, { ...event, automatic: true });
         if (recorded && event.source === "pf2e-reaction-card" && REACTION_STRIKE_SLUGS.has(event.actionSlug)) {
           this.addReactionStrikeIntent(event.actorId, event.actionSlug);
         }
         if (recorded && event.movement && event.resource === "action") {
-          MovementIntent.add({ actorId: event.actorId, combatantId: combatant.id, slug: event.slug, cost: event.cost, identity: event.identity });
+          MovementIntent.add({ actorId: event.actorId, combatantId: combatant.id, slug: event.slug,
+            movementType: PF2eAdapter.getMovementType(event.slug), cost: event.cost, identity: event.identity, paid: true });
         }
       }
       return;

--- a/scripts/encounter/turn-assistant/detectors/activity-detector.js
+++ b/scripts/encounter/turn-assistant/detectors/activity-detector.js
@@ -11,20 +11,23 @@ export class ActivityDetector {
     if (!actor || !item || !cost) return null;
 
     if (!context) {
-      if (cost.type !== "reaction" || !PF2eAdapter.isItemUsageMessage(message, item)) return null;
+      if (!PF2eAdapter.hasVerifiedItemOrigin(message, item)) return null;
+      if (PF2eAdapter.getActivitySlug(item) === "stand") return null;
       return {
-        actorId: actor.id, resource: "reaction", cost: 1,
-        label: item.name ?? "PF2e Reaction", confidence: "certain", identity: `message:${message.id}`,
+        actorId: actor.id, resource: cost.type, cost: cost.value,
+        label: item.name ?? "PF2e Activity", confidence: "certain", identity: `message:${message.id}`,
+        movement: PF2eAdapter.isMovementActivity(item),
         slug: PF2eAdapter.getActivitySlug(item), actionSlug: PF2eAdapter.getActivitySlug(item),
         actionUuid: item.uuid ?? null, sourceUuid: item.sourceId ?? item.flags?.core?.sourceId ?? null,
-        source: "pf2e-reaction-card",
+        source: cost.type === "reaction" ? "pf2e-reaction-card" : "pf2e-chat-activity",
       };
     }
 
     const type = String(context.type ?? "");
     if (type.includes("damage") || type.includes("healing")) return null;
-    const executed = type.includes("roll") || type === "spell-cast" || type === "self-effect" || context.outcome != null;
+    const executed = type.includes("roll") || type === "check" || type === "spell-cast" || type === "self-effect" || context.outcome != null;
     if (!executed) return null;
+    if (PF2eAdapter.getActivitySlug(item) === "stand") return null;
     return {
       actorId: actor.id, resource: cost.type, cost: cost.value,
       label: item.name ?? message.flavor ?? "PF2e Activity",
@@ -32,6 +35,7 @@ export class ActivityDetector {
       movement: PF2eAdapter.isMovementActivity(item),
       slug: PF2eAdapter.getActivitySlug(item), actionSlug: PF2eAdapter.getActivitySlug(item),
       actionUuid: item.uuid ?? null, sourceUuid: item.sourceId ?? item.flags?.core?.sourceId ?? null,
+      source: "pf2e-chat-activity",
     };
   }
 }

--- a/scripts/encounter/turn-assistant/movement-intent.js
+++ b/scripts/encounter/turn-assistant/movement-intent.js
@@ -8,12 +8,12 @@ export class MovementIntent {
     return `${actorId}:${combatantId}`;
   }
 
-  static add({ actorId, combatantId, slug, cost, identity }) {
+  static add({ actorId, combatantId, slug, movementType = null, cost, identity, paid = false }) {
     if (!actorId || !combatantId) return;
     this.prune();
     const key = this.key(actorId, combatantId);
     const queue = this.intents.get(key) ?? [];
-    queue.push({ actorId, combatantId, slug, cost, identity, paid: true, createdAt: Date.now() });
+    queue.push({ actorId, combatantId, slug, movementType, cost, identity, paid, createdAt: Date.now() });
     this.intents.set(key, queue);
   }
 

--- a/scripts/encounter/turn-assistant/movement-tracker.js
+++ b/scripts/encounter/turn-assistant/movement-tracker.js
@@ -1,5 +1,6 @@
 import { ActionTracker } from "./action-tracker.js";
 import { MovementIntent } from "./movement-intent.js";
+import { PF2eAdapter } from "../../integrations/pf2e.js";
 
 const MODULE_ID = "pf2e-token-bar";
 const POSITION_KEYS = ["x", "y", "elevation"];
@@ -7,13 +8,24 @@ const POSITION_KEYS = ["x", "y", "elevation"];
 /** Debounces TokenDocument updates and turns one continuous move into one action event. */
 export class MovementTracker {
   static pending = new Map();
+  static previousPositions = new Map();
   static sequence = 0;
 
   static registerHooks() {
+    Hooks.on("preUpdateToken", (token, changes) => this.capturePreviousPosition(token, changes));
     Hooks.on("updateToken", (token, changes, options, userId) => this.onTokenUpdate(token, changes, options, userId));
     Hooks.on("deleteCombat", () => this.clear());
     Hooks.on("updateCombat", combat => { if (!combat.started) this.clear(); });
     Hooks.on("canvasTearDown", () => this.clear());
+  }
+
+  static tokenKey(token) {
+    return `${token.parent?.id ?? token.scene?.id ?? "scene"}:${token.id}`;
+  }
+
+  static capturePreviousPosition(token, changes) {
+    if (!POSITION_KEYS.some(key => Object.prototype.hasOwnProperty.call(changes, key))) return;
+    this.previousPositions.set(this.tokenKey(token), this.position(token, {}));
   }
 
   static onTokenUpdate(token, changes, options = {}, userId) {
@@ -28,20 +40,28 @@ export class MovementTracker {
     if (game.settings.get(MODULE_ID, "onlyTrackActiveCombatant") && combatant.id !== combat.combatant.id) return;
     if (this.ignoreGMMovement(token.actor, userId)) return;
 
-    const key = `${token.parent?.id ?? token.scene?.id ?? "scene"}:${token.id}`;
+    const key = this.tokenKey(token);
     const position = this.position(token, changes);
+    const previous = this.previousPositions.get(key);
+    this.previousPositions.delete(key);
+    if (!previous || this.samePosition(previous, position)) return;
+    const segmentDistance = this.measureSegment(token, previous, position);
+    if (!(segmentDistance > 0)) return;
     let session = this.pending.get(key);
     if (!session) {
+      const intent = MovementIntent.consume(token.actor.id, combatant.id);
       session = {
         tokenId: token.id, actorId: token.actor.id, combatId: combat.id, combatantId: combatant.id,
         sessionId: `${Date.now().toString(36)}-${++this.sequence}`, startedAt: Date.now(),
-        lastUpdate: Date.now(), position, timer: null,
+        lastUpdate: Date.now(), position, distance: segmentDistance,
+        movementType: intent?.movementType ?? "land", intent, timer: null,
       };
       this.pending.set(key, session);
       ActionTracker.debug("Movement started", { actor: token.actor.name, token: token.name });
     } else {
       if (this.samePosition(session.position, position)) return;
       session.position = position;
+      session.distance += segmentDistance;
       session.lastUpdate = Date.now();
       clearTimeout(session.timer);
       ActionTracker.debug("Movement update received", { actor: token.actor.name, token: token.name });
@@ -60,19 +80,46 @@ export class MovementTracker {
     if (!combat?.started || combat.id !== session.combatId || !combatant || game.paused) return;
     if (game.settings.get(MODULE_ID, "onlyTrackActiveCombatant") && combat.combatant?.id !== combatant.id) return;
 
-    ActionTracker.debug("Movement completed", session);
-    const intent = MovementIntent.consume(session.actorId, session.combatantId);
-    if (intent) {
-      ActionTracker.debug("Movement intent found; skipping additional movement cost", intent);
+    if (session.intent?.paid) {
+      ActionTracker.debug("Movement intent found; skipping additional movement cost", session.intent);
       return;
     }
+    const speed = PF2eAdapter.getMovementSpeed(combatant.actor, session.movementType);
+    if (!speed) {
+      ActionTracker.debug("Movement session ignored / fallback", { actor: combatant.actor?.name,
+        type: session.movementType, reason: `no reliable current ${session.movementType} speed` });
+      return;
+    }
+    const cost = this.actionsRequired(session.distance, speed);
+    if (!cost) return;
     const identity = `movement:${session.combatId}:${session.combatantId}:${session.sessionId}`;
-    ActionTracker.debug("No movement intent found; spending 1 action", { identity });
+    const distance = Math.round(session.distance * 100) / 100;
+    const typeLabel = game.i18n.localize(`PF2ETokenBar.TurnAssistant.MovementType.${session.movementType}`);
+    const units = globalThis.canvas?.scene?.grid?.units || game.i18n.localize("PF2ETokenBar.TurnAssistant.DistanceUnits");
+    ActionTracker.debug("Movement session finalized", { actor: combatant.actor?.name, type: session.movementType,
+      distance, speed, actionsRequired: cost });
     await ActionTracker.record(combatant, {
-      resource: "action", cost: 1,
-      label: game.i18n.localize("PF2ETokenBar.TurnAssistant.Movement"),
+      resource: "action", cost,
+      label: `${typeLabel} ${distance} ${units}`,
       automatic: true, source: "token-movement", identity,
     });
+  }
+
+  static actionsRequired(distance, speed) {
+    const travelled = Number(distance); const effectiveSpeed = Number(speed);
+    return travelled > 0 && effectiveSpeed > 0 ? Math.ceil(travelled / effectiveSpeed) : 0;
+  }
+
+  /** Foundry V14's grid path measurement honors scene units and diagonal rules. */
+  static measureSegment(token, from, to) {
+    const grid = globalThis.canvas?.grid;
+    if (!grid?.measurePath) return 0;
+    const size = globalThis.canvas?.dimensions?.size ?? grid.size ?? 0;
+    const width = Number(token.width ?? 1) * size;
+    const height = Number(token.height ?? 1) * size;
+    const waypoint = point => ({ x: point.x + width / 2, y: point.y + height / 2, elevation: point.elevation });
+    const measurement = grid.measurePath([waypoint(from), waypoint(to)]);
+    return Number(measurement?.distance) || 0;
   }
 
   static findCombatant(token, combat) {
@@ -100,6 +147,7 @@ export class MovementTracker {
   static clear() {
     for (const session of this.pending.values()) clearTimeout(session.timer);
     this.pending.clear();
+    this.previousPositions.clear();
     MovementIntent.clear();
   }
 }

--- a/scripts/integrations/pf2e.js
+++ b/scripts/integrations/pf2e.js
@@ -12,6 +12,10 @@ export class PF2eAdapter {
   static KIP_UP_SLUG = "kip-up";
   static KIP_UP_SOURCE_ID = "Compendium.pf2e.feats-srd.Item.gBSPbQRXdagZTUwY";
   static MOVEMENT_ACTION_SLUGS = new Set(["stride", "step", "climb", "swim", "crawl", "sneak", "leap", "high-jump", "long-jump", "fly"]);
+  static DISTANCE_MOVEMENT_TYPES = new Map([
+    ["stride", "land"], ["sneak", "land"], ["fly", "fly"], ["climb", "climb"], ["swim", "swim"],
+  ]);
+  static FIXED_MOVEMENT_SLUGS = new Set(["step", "crawl", "leap", "high-jump", "long-jump"]);
   // PF2e 7.8 (Foundry V14) SystemActions definitions. Used only if the public
   // game.pf2e.actions collection is unavailable or does not contain the action.
   static MOVEMENT_ACTION_COSTS = new Map([
@@ -37,6 +41,17 @@ export class PF2eAdapter {
     const value = cost.type === "action" ? Number(cost.value) : cost.type === "reaction" ? 1 : 0;
     if (cost.type === "action" && ![1, 2, 3].includes(value)) return null;
     return { type: cost.type, value };
+  }
+
+  /** PF2e V14 exposes current, derived creature speeds at actor.movement.speeds. */
+  static getMovementSpeed(actor, movementType = "land") {
+    const speed = actor?.movement?.speeds?.[movementType];
+    const value = Number(speed?.value ?? speed?.total ?? speed);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  }
+
+  static getMovementType(slug) {
+    return this.DISTANCE_MOVEMENT_TYPES.get(slug) ?? null;
   }
 
   static getActivitySlug(item) {
@@ -82,6 +97,10 @@ export class PF2eAdapter {
     const sourceId = item.sourceId ?? item.flags?.core?.sourceId;
     const sourceMatches = typeof origin.sourceId === "string" && origin.sourceId === sourceId;
     return uuidMatches || sourceMatches;
+  }
+
+  static hasVerifiedItemOrigin(message, item) {
+    return this.isItemUsageMessage(message, item);
   }
 
   /** Resolve a unique supported action from PF2e's sorted check roll options. */

--- a/tests/turn-assistant.test.mjs
+++ b/tests/turn-assistant.test.mjs
@@ -78,6 +78,8 @@ const { ActivityDetector } = await import("../scripts/encounter/turn-assistant/d
 const { ActionState } = await import("../scripts/encounter/turn-assistant/action-state.js");
 const { ActionTracker } = await import("../scripts/encounter/turn-assistant/action-tracker.js");
 const { ProneTracker } = await import("../scripts/encounter/turn-assistant/prone-tracker.js");
+const { MovementTracker } = await import("../scripts/encounter/turn-assistant/movement-tracker.js");
+const { MovementIntent } = await import("../scripts/encounter/turn-assistant/movement-intent.js");
 
 function reactionState(slugs = []) {
   const actor = { items: slugs.map((slug, i) => ({ id: `i${i}`, slug })) };
@@ -175,6 +177,78 @@ test("reaction cards require a matching PF2e item origin and ignore rerolls", ()
   assert.equal(ActivityDetector.detect(reroll), null);
 });
 
+function activityMessage(cost, { id = `activity-${cost.type}-${cost.value}`, context = null, external = false } = {}) {
+  const actor = { id: "activity-actor" };
+  const item = { actor, name: "Structured Activity", slug: "structured-activity",
+    uuid: "Actor.activity-actor.Item.activity", actionCost: cost };
+  return { id, actor, item, flags: { pf2e: {
+    origin: { uuid: item.uuid, type: "action" },
+    ...(context ? { context } : {}),
+    ...(external ? { externalModule: true } : {}),
+  } }, content: "<p>Localized text is intentionally irrelevant</p>" };
+}
+
+test("structured PF2e item cards support 1/2/3 actions, free actions, and external modules", () => {
+  for (const value of [1, 2, 3]) {
+    const event = ActivityDetector.detect(activityMessage({ type: "action", value }, { external: true }));
+    assert.equal(event.resource, "action"); assert.equal(event.cost, value);
+    assert.equal(event.source, "pf2e-chat-activity");
+  }
+  const free = ActivityDetector.detect(activityMessage({ type: "free", value: null }));
+  assert.equal(free.resource, "free"); assert.equal(free.cost, 0);
+  const rolled = ActivityDetector.detect(activityMessage({ type: "action", value: 2 }, { context: { type: "check", outcome: "success", options: [] } }));
+  assert.equal(rolled.cost, 2);
+});
+
+test("chat HTML without structured PF2e actor/item/origin data is ignored", () => {
+  assert.equal(ActivityDetector.detect({ id: "text", content: "<p>Stride</p>", flavor: "Aktion" }), null);
+});
+
+test("Stand remains deferred to ProneTracker", () => {
+  const card = activityMessage({ type: "action", value: 1 }); card.item.slug = "stand";
+  assert.equal(ActivityDetector.detect(card), null);
+});
+
+test("movement cost uses exact speed boundaries and permits overspend-sized costs", () => {
+  for (const [distance, expected] of [[0, 0], [10, 1], [30, 1], [31, 2], [50, 2], [60, 2], [61, 3], [90, 3], [100, 4]]) {
+    assert.equal(MovementTracker.actionsRequired(distance, 30), expected);
+  }
+  assert.equal(MovementTracker.actionsRequired(50, 40), 2, "fly speed");
+  assert.equal(MovementTracker.actionsRequired(25, 15), 2, "climb speed");
+});
+
+test("multi-segment movement sums every measured turn rather than its endpoints", () => {
+  globalThis.canvas = {
+    dimensions: { size: 100 },
+    grid: { measurePath: ([from, to]) => ({ distance: Math.abs(to.x - from.x) / 5 + Math.abs(to.y - from.y) / 5 }) },
+  };
+  const token = { width: 1, height: 1 };
+  const points = [{ x: 0, y: 0, elevation: 0 }, { x: 100, y: 0, elevation: 0 },
+    { x: 100, y: 100, elevation: 0 }, { x: 150, y: 100, elevation: 0 }];
+  const distance = points.slice(1).reduce((sum, point, index) => sum + MovementTracker.measureSegment(token, points[index], point), 0);
+  assert.equal(distance, 50); assert.equal(MovementTracker.actionsRequired(distance, 30), 2);
+  delete globalThis.canvas;
+});
+
+test("PF2e derived movement speeds and movement slug classification are used", () => {
+  const actor = { movement: { speeds: { land: { value: 30 }, fly: { value: 40 }, climb: { value: 15 }, swim: null } } };
+  assert.equal(PF2eAdapter.getMovementSpeed(actor), 30);
+  assert.equal(PF2eAdapter.getMovementSpeed(actor, "fly"), 40);
+  assert.equal(PF2eAdapter.getMovementSpeed(actor, "climb"), 15);
+  assert.equal(PF2eAdapter.getMovementSpeed(actor, "swim"), null);
+  assert.deepEqual(["stride", "sneak", "fly", "climb", "swim"].map(slug => PF2eAdapter.getMovementType(slug)),
+    ["land", "land", "fly", "climb", "swim"]);
+  for (const slug of ["step", "crawl", "leap", "high-jump", "long-jump", "stand"]) assert.equal(PF2eAdapter.getMovementType(slug), null);
+});
+
+test("movement intent carries type and paid state for chat/token deduplication", () => {
+  settingValues.set("movementIntentTimeout", 8000); MovementIntent.clear();
+  MovementIntent.add({ actorId: "a", combatantId: "c", slug: "fly", movementType: "fly", cost: 1, identity: "message:m", paid: false });
+  const intent = MovementIntent.consume("a", "c");
+  assert.equal(intent.movementType, "fly"); assert.equal(intent.paid, false); assert.equal(intent.identity, "message:m");
+  assert.equal(MovementIntent.consume("a", "c"), null);
+});
+
 test("reaction strike intent suppresses exactly one correlated strike roll", () => {
   ActionTracker.reactionStrikeIntents.clear();
   ActionTracker.addReactionStrikeIntent("reactor", "reactive-strike", 100);
@@ -223,6 +297,14 @@ test("prone removal charges only the active combatant, supports Kip Up, overspen
   assert.equal(state.history.at(-1).label, "PF2ETokenBar.TurnAssistant.Stand");
   assert.equal(await ProneTracker.onDeleteItem(prone), false, "the deterministic identity deduplicates a repeated hook/signal");
   assert.equal(state.actions.remaining, 2);
+  await ActionTracker.undoLocal(combatant); assert.equal(state.actions.remaining, 3);
+
+  assert.equal(await ActionTracker.recordLocal(combatant, { resource: "action", cost: 2, label: "Move 50 ft", identity: "movement:test" }), true);
+  assert.equal(state.actions.remaining, 1); assert.equal(state.history.at(-1).cost, 2);
+  await ActionTracker.undoLocal(combatant); assert.equal(state.actions.remaining, 3, "one undo restores the whole movement session");
+
+  assert.equal(await ActionTracker.recordLocal(combatant, { resource: "action", cost: 4, label: "Move 100 ft", identity: "movement:overspend" }), true);
+  assert.equal(state.actions.remaining, 0); assert.equal(state.overSpent, true); assert.equal(state.history.at(-1).cost, 4);
   await ActionTracker.undoLocal(combatant); assert.equal(state.actions.remaining, 3);
 
   actor.items = [{ type: "feat", slug: "kip-up" }];


### PR DESCRIPTION
### Motivation
- Make action detection rely on structured PF2e chat data so actions from external modules are detected reliably instead of depending on UI button clicks.
- Charge movement actions based on the actual path distance and the actor's derived PF2e V14 speed rather than billing a flat single action per movement session.
- Preserve existing trackers, authority/socket/history/undo semantics and avoid runtime imports from the `reference/pf2e` tree while verifying V14 data shapes.

### Description
- Extend `PF2eAdapter` with `getMovementSpeed()`, `getMovementType()`, `DISTANCE_MOVEMENT_TYPES` and `FIXED_MOVEMENT_SLUGS` and centralize reliable PF2e field handling (action cost, origin, context, traits) in `scripts/integrations/pf2e.js`.
- Update `ActivityDetector` to prefer structured PF2e data (actor, item, `flags.pf2e.origin`, `flags.pf2e.context`, `actionCost`, slugs, roll options) and emit generic `pf2e-chat-activity` events for item-based cards while deferring `stand` to `ProneTracker`.
- Have `ActionTracker` create typed `MovementIntent` entries for chat-origin movement actions (unpaid/paid state and `movementType`) and keep detector priority and idempotency (`message:<id>` identity) intact.
- Extend `MovementIntent` to carry `movementType`, `paid`, and `identity` for clean chat/token deduplication.
- Rework `MovementTracker` to capture `preUpdateToken` positions, measure each update segment with Foundry V14 `canvas.grid.measurePath()`, accumulate segment distances in a debounced session, resolve the actor's current derived speed at finalization via `PF2eAdapter.getMovementSpeed()`, compute cost with `actionsRequired = ceil(distance / speed)`, and record the full multi-action movement as a single history entry (with localized label like `Move 50 ft`).
- Preserve fixed-cost behavior for `step`, `crawl`, `leap`, `high-jump`, and `long-jump` and avoid applying the distance formula to actions that are rulewise fixed; treat `stride/sneak/fly/climb/swim` as distance-based when appropriate.
- Add `docs/action-movement-tracking.md` documenting verified reference files, pipeline, movement mapping and limitations, and update localization (`lang/en.json`, `lang/de.json`) to include movement labels/units.

### Testing
- Ran syntax checks with `find scripts -name "*.js" -print0 | xargs -0 -n1 node --check` which succeeded for all modified JS files.
- Executed unit tests with `node --test tests/*.test.mjs` and all tests passed (24 tests, 0 failures) including new coverage for structured chat messages, movement distance boundaries, multi-segment measurement, intent deduplication, undo and overspend behavior.
- Verified JSON language files parse with `node -e 'JSON.parse(require("fs").readFileSync("lang/en.json")); JSON.parse(require("fs").readFileSync("lang/de.json"))'` and ran `git diff --check` to ensure no trailing whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f924ed8a0832797c5e8cc5470f59b)